### PR TITLE
feat: pin snapshot, trim image, add intel-ucode, disable IPv6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 ---
 name: Build
 
+# Snapshot date and Docker image digest are pinned together.
+# To upgrade the full stack, update both values here and open a PR.
+# See README.md "Updating the stack" for the full process.
+env:
+  ARCH_SNAPSHOT: "2026/03/22"  # archive.archlinux.org date — update to upgrade
+
 on:
   push:
     branches: [test]
@@ -21,7 +27,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     container:
-      image: archlinux/archlinux:latest
+      # archlinux/archlinux:latest — pinned digest matches ARCH_SNAPSHOT above
+      image: archlinux/archlinux@sha256:0e2b66488c60a96c65041cde5e754957a880b760dd4f00865ed09c131a51cd44
     steps:
       - uses: actions/checkout@v5
 
@@ -41,7 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     container:
-      image: archlinux/archlinux:latest
+      # archlinux/archlinux:latest — pinned digest matches ARCH_SNAPSHOT above
+      image: archlinux/archlinux@sha256:0e2b66488c60a96c65041cde5e754957a880b760dd4f00865ed09c131a51cd44
       options: --privileged
     steps:
       - uses: actions/checkout@v5

--- a/profile/airootfs/etc/mkinitcpio.conf.d/archiso.conf
+++ b/profile/airootfs/etc/mkinitcpio.conf.d/archiso.conf
@@ -1,1 +1,5 @@
-HOOKS=(base udev autodetect modconf block filesystems fsck)
+# autodetect is intentionally omitted: it scans /sys at build time, which in a
+# CI container reflects the runner VM hardware, not the target ThinkPad. Without
+# it, mkinitcpio includes all modules for the block/filesystems hooks — correct
+# for any hardware in the ThinkPad pool.
+HOOKS=(base udev modconf block filesystems fsck)

--- a/profile/airootfs/etc/modprobe.d/blacklist-wireless.conf
+++ b/profile/airootfs/etc/modprobe.d/blacklist-wireless.conf
@@ -1,0 +1,7 @@
+# Server is wired-only — disable WiFi and Bluetooth drivers.
+# Firmware for these is also stripped via NoExtract in pacman.conf.
+blacklist iwlwifi
+blacklist cfg80211
+blacklist bluetooth
+blacklist btusb
+blacklist rfkill

--- a/profile/airootfs/etc/systemd/networkd.conf.d/ipv6-privacy-extensions.conf
+++ b/profile/airootfs/etc/systemd/networkd.conf.d/ipv6-privacy-extensions.conf
@@ -1,2 +1,0 @@
-[Network]
-IPv6PrivacyExtensions=yes

--- a/profile/packages.x86_64
+++ b/profile/packages.x86_64
@@ -3,13 +3,11 @@ base
 linux
 linux-firmware
 mkinitcpio
+intel-ucode
 openssh
 pv
 
-# boot
-efibootmgr
-
-# Harbor Serve
+# Harbor Srv
 docker
 docker-compose
 nfs-utils

--- a/profile/pacman.conf
+++ b/profile/pacman.conf
@@ -26,7 +26,33 @@ Architecture = auto
 #IgnoreGroup =
 
 #NoUpgrade   =
-#NoExtract   =
+
+# Strip files not needed on a headless server — documentation, locale data,
+# WiFi/Bluetooth firmware (server is wired-only), and GPU firmware for
+# hardware not present in ThinkPads.
+NoExtract  = usr/share/man/*
+NoExtract  = usr/share/doc/*
+NoExtract  = usr/share/info/*
+NoExtract  = usr/share/locale/*
+NoExtract  = usr/share/bash-completion/completions/*
+NoExtract  = usr/lib/firmware/amdgpu/*
+NoExtract  = usr/lib/firmware/radeon/*
+NoExtract  = usr/lib/firmware/nvidia/*
+NoExtract  = usr/lib/firmware/brcm/*
+NoExtract  = usr/lib/firmware/iwlwifi-*
+NoExtract  = usr/lib/firmware/intel/ibt-*
+NoExtract  = usr/lib/firmware/ath10k/*
+NoExtract  = usr/lib/firmware/ath11k/*
+NoExtract  = usr/lib/firmware/ath12k/*
+NoExtract  = usr/lib/firmware/qca/*
+NoExtract  = usr/lib/firmware/liquidio/*
+NoExtract  = usr/lib/firmware/netronome/*
+NoExtract  = usr/lib/firmware/mellanox/*
+NoExtract  = usr/lib/firmware/qed/*
+NoExtract  = usr/lib/firmware/cxgb4/*
+NoExtract  = usr/lib/firmware/cxgb3/*
+NoExtract  = usr/lib/firmware/bnx2/*
+NoExtract  = usr/lib/firmware/bnx2x/*
 
 # Misc options
 #UseSyslog
@@ -51,50 +77,14 @@ LocalFileSigLevel = Optional
 
 #
 # REPOSITORIES
-#   - can be defined here or included from another file
-#   - pacman will search repositories in the order defined here
-#   - local/custom mirrors can be added here or in separate files
-#   - repositories listed first will take precedence when packages
-#     have identical names, regardless of version number
-#   - URLs will have $repo replaced by the name of the current repo
-#   - URLs will have $arch replaced by the name of the architecture
 #
-# Repository entries are of the format:
-#       [repo-name]
-#       Server = ServerName
-#       Include = IncludePath
+# Pinned to archive.archlinux.org snapshot. The @ARCH_SNAPSHOT@ placeholder
+# is substituted by build-image.sh using the ARCH_SNAPSHOT env var set in
+# .github/workflows/build.yml. Update ARCH_SNAPSHOT there to upgrade.
 #
-# The header [repo-name] is crucial - it must be present and
-# uncommented to enable the repo.
-#
-
-# The testing repositories are disabled by default. To enable, uncomment the
-# repo name header and Include lines. You can add preferred servers immediately
-# after the header, and they will be used before the default mirrors.
-
-#[core-testing]
-#Include = /etc/pacman.d/mirrorlist
 
 [core]
-Include = /etc/pacman.d/mirrorlist
-
-#[extra-testing]
-#Include = /etc/pacman.d/mirrorlist
+Server = https://archive.archlinux.org/repos/@ARCH_SNAPSHOT@/$repo/os/$arch
 
 [extra]
-Include = /etc/pacman.d/mirrorlist
-
-# If you want to run 32 bit applications on your x86_64 system,
-# enable the multilib repositories as required here.
-
-#[multilib-testing]
-#Include = /etc/pacman.d/mirrorlist
-
-#[multilib]
-#Include = /etc/pacman.d/mirrorlist
-
-# An example of a custom package repository.  See the pacman manpage for
-# tips on creating your own repositories.
-#[custom]
-#SigLevel = Optional TrustAll
-#Server = file:///home/custompkgs
+Server = https://archive.archlinux.org/repos/@ARCH_SNAPSHOT@/$repo/os/$arch

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -57,8 +57,18 @@ mount "$LOOP_DEV" "${WORK_DIR}/mnt"
 mapfile -t PACKAGES < <(sed -e '/^#/d' -e '/^$/d' "${PROFILE_DIR}/packages.x86_64")
 echo ":: Installing ${#PACKAGES[@]} packages via pacstrap..."
 
-# --- Pacstrap (without running mkinitcpio via pacman hooks) ---
+# --- Patch pacman.conf snapshot date ---
+# ARCH_SNAPSHOT is set in .github/workflows/build.yml and substituted into the
+# archive.archlinux.org Server URLs. Update it there to upgrade the full stack.
 PACMAN_CONF="${PROFILE_DIR}/pacman.conf"
+if [ -f "$PACMAN_CONF" ]; then
+    PATCHED_PACMAN_CONF="${WORK_DIR}/pacman.conf"
+    sed "s|@ARCH_SNAPSHOT@|${ARCH_SNAPSHOT:?ARCH_SNAPSHOT env var is required}|g" \
+        "$PACMAN_CONF" > "$PATCHED_PACMAN_CONF"
+    PACMAN_CONF="$PATCHED_PACMAN_CONF"
+fi
+
+# --- Pacstrap (without running mkinitcpio via pacman hooks) ---
 
 # Create a hook override to skip mkinitcpio during pacstrap.
 # We run it manually after copying the overlay with our custom preset/config.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -96,7 +96,7 @@ EOF
 mkdir -p "${MOUNT_DIR}/etc/harbor"
 cp "$CONF" "${MOUNT_DIR}/etc/harbor/partitions.conf"
 
-# Copy kernel and initramfs to ESP
+# Copy kernel, microcode, and initramfs to ESP
 ESP_MOUNT=$(findmnt -n -o TARGET /boot/efi 2>/dev/null || echo "")
 if [ -z "$ESP_MOUNT" ]; then
     mkdir -p /boot/efi
@@ -104,6 +104,7 @@ if [ -z "$ESP_MOUNT" ]; then
     ESP_MOUNT="/boot/efi"
 fi
 cp "${MOUNT_DIR}/boot/vmlinuz-linux" "${ESP_MOUNT}/"
+cp "${MOUNT_DIR}/boot/intel-ucode.img" "${ESP_MOUNT}/"
 cp "${MOUNT_DIR}/boot/initramfs-linux.img" "${ESP_MOUNT}/"
 
 # Write boot entry with try-counter for automatic fallback.
@@ -116,8 +117,9 @@ rm -f "${ENTRIES_DIR}/${TARGET_ENTRY_BASE}"+*.conf
 cat > "${ENTRIES_DIR}/${TARGET_ENTRY}" << EOF
 title   Harbor Srv (${TARGET_LABEL})
 linux   /vmlinuz-linux
+initrd  /intel-ucode.img
 initrd  /initramfs-linux.img
-options root=PARTUUID=${TARGET_PARTUUID} rw
+options root=PARTUUID=${TARGET_PARTUUID} rw ipv6.disable=1
 EOF
 
 # Set default using a glob so it matches both the counted and blessed forms.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -121,19 +121,22 @@ EOF
 cat > "${MOUNT_DIR}/boot/efi/loader/entries/harbor-a.conf" << EOF
 title   Harbor Srv (Root A)
 linux   /vmlinuz-linux
+initrd  /intel-ucode.img
 initrd  /initramfs-linux.img
-options root=PARTUUID=${ROOT_A_PARTUUID} rw
+options root=PARTUUID=${ROOT_A_PARTUUID} rw ipv6.disable=1
 EOF
 
 cat > "${MOUNT_DIR}/boot/efi/loader/entries/harbor-b.conf" << EOF
 title   Harbor Srv (Root B)
 linux   /vmlinuz-linux
+initrd  /intel-ucode.img
 initrd  /initramfs-linux.img
-options root=PARTUUID=${ROOT_B_PARTUUID} rw
+options root=PARTUUID=${ROOT_B_PARTUUID} rw ipv6.disable=1
 EOF
 
-# Copy kernel and initramfs to ESP so systemd-boot can find them
+# Copy kernel, microcode, and initramfs to ESP so systemd-boot can find them
 cp "${MOUNT_DIR}/boot/vmlinuz-linux" "${MOUNT_DIR}/boot/efi/"
+cp "${MOUNT_DIR}/boot/intel-ucode.img" "${MOUNT_DIR}/boot/efi/"
 cp "${MOUNT_DIR}/boot/initramfs-linux.img" "${MOUNT_DIR}/boot/efi/"
 
 # Create fstab


### PR DESCRIPTION
## Summary

- **Reproducibility**: Pin CI container to a specific `archlinux/archlinux` digest and packages to `archive.archlinux.org` snapshot. To upgrade the full stack, update `ARCH_SNAPSHOT` and the Docker digest in `.github/workflows/build.yml` — nothing else.
- **Image size**: `NoExtract` in `pacman.conf` strips docs, locale data, and firmware for hardware not present in ThinkPads (AMD/NVIDIA GPU, WiFi, Bluetooth, Broadcom, Qualcomm, datacenter NICs).
- **mkinitcpio correctness**: Remove `autodetect` hook — CI container scans the runner VM's `/sys`, not ThinkPad hardware. Without it, all block/filesystem modules are included unconditionally, which is correct for any ThinkPad in the pool.
- **intel-ucode**: CPU microcode was entirely missing. Added package + wired up `intel-ucode.img` in boot entries and ESP copy steps in `install.sh` and `deploy.sh`.
- **IPv6**: Disabled via `ipv6.disable=1` kernel parameter (attack surface reduction). Removed now-dead `ipv6-privacy-extensions.conf`.
- **WiFi/Bluetooth**: Firmware stripped via `NoExtract`; kernel modules blacklisted via `modprobe.d`.
- **Removed `efibootmgr`**: Unused at runtime — `bootctl` handles all boot management.

## Test plan

- [ ] CI build succeeds with pinned Docker image and archive.archlinux.org snapshot
- [ ] Image boots on ThinkPad hardware — SSH accessible
- [ ] `dmesg | grep microcode` shows microcode update applied at boot
- [ ] `ip -6 addr` shows no IPv6 addresses
- [ ] `lsmod | grep iwlwifi` shows no WiFi module loaded
- [ ] Image size is measurably smaller than pre-PR baseline
- [ ] Two builds from the same commit produce identical SHA256 checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)