### PR TITLE
chore(ci): upgrade actions/upload-artifact to v6 for Node.js 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         run: ./scripts/build-image.sh profile/ output/
 
       - name: Upload root image artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: harbor_srv-root
           path: output/


### PR DESCRIPTION
Bumps `actions/upload-artifact` from v5 to v6. v5 runs on Node.js 20 which GitHub Actions is deprecating; forced migration to Node.js 24 begins June 2, 2026.

Closes blouin-labs/issues#29