### PR TITLE
chore: promote test to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ---
-name: Build
+name: CI
 
 # Snapshot date and Docker image digest are pinned together.
 # To upgrade the full stack, update both values here and open a PR.
@@ -9,19 +9,15 @@ env:
 
 on:
   push:
-    branches: [test, main]
+    branches: [test]
     paths:
       - 'profile/**'
       - 'scripts/**'
-      - '.github/workflows/**'
-      - '!**/README.md'
   pull_request:
     branches: [test]
     paths:
       - 'profile/**'
       - 'scripts/**'
-      - '.github/workflows/**'
-      - '!**/README.md'
 
 jobs:
   select-runner:
@@ -89,19 +85,3 @@ jobs:
           name: harbor_srv-root
           path: output/
           retention-days: 30
-
-  deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs: build
-    runs-on: [self-hosted, harbor-srv]
-    steps:
-      - name: Download root image
-        uses: actions/download-artifact@v6
-        with:
-          name: harbor_srv-root
-          path: /tmp/harbor-deploy/
-
-      - name: Deploy
-        run: |
-          mv /tmp/harbor-deploy/harbor_srv-root.img.zst /tmp/harbor_srv-root.img.zst
-          sudo /usr/local/sbin/harbor-deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+---
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'profile/**'
+      - 'scripts/**'
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, harbor-srv]
+    steps:
+      - name: Find last successful CI run on test
+        id: find-run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_ID=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=test&status=success&per_page=1" \
+            --jq '.workflow_runs[0].id')
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "ERROR: no successful CI run found on test branch — nothing to deploy" >&2
+            exit 1
+          fi
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Download root image artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download "${{ steps.find-run.outputs.run_id }}" \
+            --repo "${{ github.repository }}" \
+            -n harbor_srv-root \
+            -D /tmp/harbor-deploy/
+
+      - name: Deploy
+        run: |
+          mv /tmp/harbor-deploy/harbor_srv-root.img.zst /tmp/harbor_srv-root.img.zst
+          sudo /usr/local/sbin/harbor-deploy


### PR DESCRIPTION
## Summary

Promotes the current `test` branch to `main`, including all features merged since the last release:

- Self-hosted runner with non-root isolation and bootstrap
- Automated deploy pipeline via runner sudo
- A/B boot failover via systemd-boot try-counter
- Image build switched from live ISO to raw ext4 root filesystem
- Snapshot pinning, intel-ucode, IPv6 disabled
- CI targeting `test` branch, runner fallback to shared
- Build-once CI/CD split (`ci.yml` + `deploy.yml`) — pending merge of PR #47

## Test plan

- [ ] PR #47 (`feat(ci): build-once workflow`) merged to `test` first
- [ ] CI passes on `test` (check + build)
- [ ] Manual testing complete on deployed `test` image
- [ ] Merge this PR — `deploy.yml` picks up the tested artifact and deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)