### PR TITLE
fix(deploy): replace gh CLI with curl+jq+bsdtar

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RUN_ID=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=test&status=success&per_page=1" \
-            --jq '.workflow_runs[0].id')
+          RUN_ID=$(curl -sf \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=test&status=success&per_page=1" \
+            | jq -r '.workflow_runs[0].id')
           if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
             echo "ERROR: no successful CI run found on test branch — nothing to deploy" >&2
             exit 1
@@ -30,10 +32,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh run download "${{ steps.find-run.outputs.run_id }}" \
-            --repo "${{ github.repository }}" \
-            -n harbor_srv-root \
-            -D /tmp/harbor-deploy/
+          ARTIFACT_URL=$(curl -sf \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ steps.find-run.outputs.run_id }}/artifacts" \
+            | jq -r '.artifacts[] | select(.name=="harbor_srv-root") | .archive_download_url')
+          mkdir -p /tmp/harbor-deploy/
+          curl -sL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -o /tmp/harbor-deploy/artifact.zip \
+            "$ARTIFACT_URL"
+          bsdtar -xf /tmp/harbor-deploy/artifact.zip -C /tmp/harbor-deploy/
+          rm /tmp/harbor-deploy/artifact.zip
 
       - name: Deploy
         run: |


### PR DESCRIPTION
Promotes `test` to `main` with the deploy fix.

`gh` is not installed on the self-hosted runner. Replaces `gh api` and `gh run download` with `curl` + `jq` + `bsdtar` — all present on the current server image.

## Test plan

- [ ] Merge → `deploy.yml` triggers, downloads artifact via curl, deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)