### PR TITLE
feat(deploy): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'profile/**'
       - 'scripts/**'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Adds `workflow_dispatch` to `deploy.yml` so a deploy can be manually triggered from the Actions tab — useful when a main merge only touches workflow files and the path filter doesn't fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)