### PR TITLE
feat(ci): add Promote workflow and document issue conventions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,17 +15,14 @@ README-only changes do not trigger a build.
 ```
 feat/my-thing  →  PR to staging  →  CI runs  →  merge (rebase)
                                                       ↓
-                             git push origin staging:main   ← promote when ready
+                             Actions → Promote → Run workflow   ← promote when ready
                                                       ↓
                                                deploy.yml fires
 ```
 
 Feature branch rule: always `git rebase origin/staging` before opening a PR. Never merge.
 
-Promote command (run locally, requires CI green on staging):
-```bash
-git push origin staging:main
-```
+Promote via **Actions → Promote → Run workflow**. Type `promote` to confirm. The workflow verifies CI is green on `staging` before touching `main`.
 
 ## Table of Contents
 
@@ -34,6 +31,7 @@ git push origin staging:main
   - [check job](#check-job)
   - [build job](#build-job)
   - [Artifact](#artifact)
+- [promote.yml](#promoteyml)
 - [deploy.yml](#deployyml)
 
 ---
@@ -81,6 +79,21 @@ Download with:
 ```bash
 gh run download <run-id> -n harbor_srv-root -D /tmp/deploy
 ```
+
+---
+
+## [promote.yml](promote.yml)
+
+`workflow_dispatch` only — triggered manually via the GitHub Actions UI.
+
+Requires typing `"promote"` in the confirmation input before any action is taken. Fails immediately if the input doesn't match.
+
+Steps:
+1. **Confirm** — validates the confirmation input.
+2. **Verify CI** — checks the latest `build` job on `staging` is `success`. Aborts if not.
+3. **Fast-forward main** — updates `main` to `staging`'s HEAD via the GitHub API (`force: false`). Will fail safely if the branches have somehow diverged.
+
+Triggers `deploy.yml` as a side effect of the push to `main`.
 
 ---
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,46 @@
+---
+name: Promote
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "promote" to confirm. Staging will be deployed to the production server and it will reboot.'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm
+        run: |
+          if [ "${{ inputs.confirm }}" != "promote" ]; then
+            echo "ERROR: type exactly 'promote' to confirm." >&2
+            exit 1
+          fi
+
+      - name: Verify CI is green on staging
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CONCLUSION=$(gh api \
+            "repos/${{ github.repository }}/commits/staging/check-runs" \
+            --jq '[.check_runs[] | select(.name=="build")] | sort_by(.completed_at) | last | .conclusion')
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "ERROR: latest build on staging is not successful (conclusion: $CONCLUSION)" >&2
+            exit 1
+          fi
+
+      - name: Fast-forward main to staging
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA=$(gh api "repos/${{ github.repository }}/git/refs/heads/staging" \
+            --jq '.object.sha')
+          gh api "repos/${{ github.repository }}/git/refs/heads/main" \
+            --method PATCH \
+            --field sha="$SHA" \
+            --field force=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,16 +8,14 @@ Working conventions for this repository. Keep this file up to date as the projec
 - **`main`** — production. Promoted from `staging` only, never committed to directly.
 - **Feature branches** — `feat/`, `fix/`, `docs/`, `chore/` prefixes. Always branch from `staging`.
 
-Promote staging to production:
-```bash
-git push origin staging:main   # fast-forward only — will fail if diverged
-```
+Promotion to production is done via the **Promote** workflow in GitHub Actions (Actions → Promote → Run workflow). Never push directly to `main`.
 
 Never create merge commits. Always rebase feature branches onto `staging` before opening a PR.
 
 ## CI/CD
 
 - `ci.yml` — triggers on push/PR to `staging`. Runs shellcheck then builds the root image. Artifacts retained 30 days.
+- `promote.yml` — `workflow_dispatch` only. Verifies CI is green on `staging`, then fast-forwards `main` to `staging`. Requires typing `"promote"` to confirm (server will reboot).
 - `deploy.yml` — triggers on push to `main`. Downloads the last successful CI artifact from `staging` and flashes the server via the self-hosted runner (`harbor-srv`).
 
 No deploy ever rebuilds the image — it always uses the artifact already produced by CI on `staging`.
@@ -30,9 +28,19 @@ The GitHub Actions runner (`harbor-srv`) must never have root or sudo access dir
 
 Follow [Conventional Commits](https://www.conventionalcommits.org): `feat:`, `fix:`, `docs:`, `chore:`, etc.
 
+## Issues
+
+1. **Check for a related issue before starting any non-trivial work.** Read the full issue — description and all comments — for context, prior decisions, or constraints.
+2. **All non-trivial work must be associated with an issue.** If one doesn't exist, create it first. Trivial one-liner fixes may skip this. Issues describe the *why* — motivation, constraints, desired outcome — not the implementation.
+3. **Apply labels** when creating or working an issue — type (`bug`, `enhancement`, `documentation`, `security`, `golden image`) and priority (`priority: critical/high/medium/low`).
+4. **Post the plan as an issue comment before executing.** The local plan file is Claude's scratchpad; the issue comment is the durable record.
+5. **Before adding `Closes #N` to a PR**, re-read the issue description and all comments to confirm the PR fully addresses the *why*. If the issue spans multiple PRs, use `Refs #N` instead.
+6. **Close issues with a summary** — re-read the full thread, confirm nothing was missed, close with a brief comment.
+
 ## Never do
 
-- Merge PRs or push to `main` without explicit user approval.
+- Push directly to `staging` or `main`. All work goes through a PR for the user to review. Promotion is via the Promote workflow, not direct push.
+- Merge or approve PRs unless explicitly asked.
 - Amend commits that have already been pushed.
 - Use `--force` push on any branch.
 - Grant the runner broad sudo or root access.

--- a/README.md
+++ b/README.md
@@ -100,16 +100,14 @@ bash install.sh /dev/nvme0n1 harbor_srv-root.img.zst
 
 ### Deploying an update
 
-Deployments are automatic — promoting `staging` to `main` triggers `deploy.yml`, which downloads the last successful CI artifact from `staging` and runs `harbor-deploy` on the server. No manual steps required.
+Deployments are triggered by promoting `staging` to `main`. `deploy.yml` then downloads the last successful CI artifact from `staging` and runs `harbor-deploy` on the server. The server will reboot.
 
-To promote staging to production:
-```bash
-git push origin staging:main
-```
+To promote:
 
-To trigger a deploy manually (e.g. after a workflow-only change that didn't fire the path filter):
+1. Go to **Actions → Promote → Run workflow** in the GitHub UI.
+2. Type `promote` in the confirmation box and click **Run workflow**.
 
-1. Go to **Actions → Deploy → Run workflow** in the GitHub UI.
+The workflow verifies CI is green on `staging` before touching `main`. It will refuse to proceed if the latest build is not successful.
 
 ### SSH access
 
@@ -151,11 +149,7 @@ flowchart LR
    ```
 2. **Open a PR targeting `staging`** — CI runs `check` + `build` and uploads an artifact.
 3. **Rebase and merge** into `staging` (no merge commits).
-4. **Promote when ready:**
-   ```bash
-   git push origin staging:main
-   ```
-   `deploy.yml` picks up the artifact already built by CI and flashes the server. No rebuild.
+4. **Promote when ready** via **Actions → Promote → Run workflow**. Type `promote` to confirm. `deploy.yml` picks up the artifact already built by CI and flashes the server. No rebuild.
 
 > `staging` and `main` are always at the same commit after a promotion — divergence is structurally impossible with fast-forward-only merges.
 


### PR DESCRIPTION
## Summary

- Adds `promote.yml` — a `workflow_dispatch` with a `"promote"` confirmation guard that replaces the manual `git push origin staging:main`. Verifies CI is green on staging before touching main.
- Updates `CLAUDE.md` with an Issues section (workflow, labels, plan-as-comment, Closes/Refs conventions) and strengthens the Never do section with explicit PR/merge rules.
- Updates `README.md` and `.github/workflows/README.md` to reference the new Promote button instead of the git push command.

## Test plan

- [ ] Review `promote.yml` YAML for correctness
- [ ] Confirm CLAUDE.md issues section and never-do additions look right
- [ ] Confirm README and workflows README reflect the new promote flow
- [ ] After merge: test the Promote button with a green staging CI run (first real promotion will exercise the full path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)