### PR TITLE
fix(ci): explicitly trigger deploy after promote

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   promote:
@@ -44,3 +45,8 @@ jobs:
             --method PATCH \
             --field sha="$SHA" \
             --field force=false
+
+      - name: Trigger deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy.yml --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary

- `GITHUB_TOKEN` ref updates do not fire push triggers on other workflows — this is GitHub's documented loop-prevention mechanism
- The Promote workflow was fast-forwarding `main` via the API using `GITHUB_TOKEN`, so `deploy.yml`'s push trigger never fired
- Fix: add an explicit `gh workflow run deploy.yml` step at the end of promote, and add `actions: write` to the job permissions

## Test plan

- [ ] Run Promote workflow
- [ ] Confirm Deploy workflow starts automatically immediately after promote completes
- [ ] Confirm server reboots and comes back up with the new image

Closes blouin-labs/issues#28

🤖 Generated with [Claude Code](https://claude.com/claude-code)