### PR TITLE
fix(ci): split deploy job to detect successful reboot via runner API

### DIFF
--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -64,7 +64,7 @@ jobs:
             --field sha="$SHA" \
             --field force=false
 
-  deploy:
+  download:
     needs: [promote]
     runs-on: [self-hosted, harbor-srv]
     if: ${{ always() && (inputs.action == 'promote-and-deploy' || inputs.action == 'deploy') }}
@@ -113,7 +113,60 @@ jobs:
           bsdtar -xf /tmp/harbor-deploy/artifact.zip -C /tmp/harbor-deploy/
           rm /tmp/harbor-deploy/artifact.zip
 
+      - name: Stage image
+        run: mv /tmp/harbor-deploy/harbor_srv-root.img.zst /tmp/harbor_srv-root.img.zst
+
+  flash:
+    needs: [download]
+    runs-on: [self-hosted, harbor-srv]
+    continue-on-error: true
+    if: ${{ always() && needs.download.result == 'success' }}
+    steps:
       - name: Flash server
+        run: sudo /usr/local/sbin/harbor-deploy
+
+  verify:
+    needs: [flash]
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.flash.result != 'cancelled' && needs.flash.result != 'skipped' }}
+    steps:
+      - name: Wait for runner to reboot and reconnect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mv /tmp/harbor-deploy/harbor_srv-root.img.zst /tmp/harbor_srv-root.img.zst
-          sudo /usr/local/sbin/harbor-deploy
+          OFFLINE_TIMEOUT=90
+          ONLINE_TIMEOUT=300
+          POLL=10
+
+          echo "Phase 1: waiting for harbor-srv to go offline (reboot started)..."
+          elapsed=0
+          status=""
+          while [ "$elapsed" -lt "$OFFLINE_TIMEOUT" ]; do
+            status=$(gh api "repos/${{ github.repository }}/actions/runners" \
+              --jq '.runners[] | select(.name == "harbor-srv") | .status')
+            [ "$status" = "offline" ] && break
+            echo "  status=${status:-not found}, elapsed=${elapsed}s"
+            sleep "$POLL"
+            elapsed=$((elapsed + POLL))
+          done
+          if [ "$status" != "offline" ]; then
+            echo "ERROR: harbor-srv never went offline — reboot may not have started" >&2
+            exit 1
+          fi
+          echo "Runner is offline. Waiting for it to come back..."
+
+          echo "Phase 2: waiting for harbor-srv to come back online..."
+          elapsed=0
+          while [ "$elapsed" -lt "$ONLINE_TIMEOUT" ]; do
+            status=$(gh api "repos/${{ github.repository }}/actions/runners" \
+              --jq '.runners[] | select(.name == "harbor-srv") | .status')
+            [ "$status" = "online" ] && break
+            echo "  status=${status}, elapsed=${elapsed}s"
+            sleep "$POLL"
+            elapsed=$((elapsed + POLL))
+          done
+          if [ "$status" != "online" ]; then
+            echo "ERROR: harbor-srv did not come back online within ${ONLINE_TIMEOUT}s" >&2
+            exit 1
+          fi
+          echo "Runner is back online — deploy succeeded."


### PR DESCRIPTION
## Summary

- Splits the old `deploy` job into `download` → `flash` → `verify`
- `download` (harbor-srv): resolves the build artifact and stages the image at `/tmp/harbor_srv-root.img.zst`
- `flash` (harbor-srv, `continue-on-error: true`): calls `harbor-deploy`; expected to be killed by the reboot — this is no longer a failure signal
- `verify` (ubuntu-latest): polls `GET /repos/.../actions/runners` for the `harbor-srv` runner — waits up to 90s for it to go **offline** (reboot started), then up to 300s for it to come back **online** (boot succeeded)

Since `download` and `flash` both run on the same machine, the staged image persists on local disk between jobs — no inter-job artifact upload needed.

## Test plan

- [ ] Trigger `promote-and-deploy` or `deploy` and confirm `"ok reboot"`
- [ ] Verify `flash` job no longer shows red after reboot
- [ ] Verify `verify` job logs both phases and exits 0
- [ ] SSH to server and confirm root partition flipped to the inactive slot

Closes blouin-labs/issues#5

🤖 Generated with [Claude Code](https://claude.com/claude-code)