### PR TITLE
fix(deploy): defer reboot so flash step can report success before shutdown

### DIFF
--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -119,7 +119,6 @@ jobs:
   flash:
     needs: [download]
     runs-on: [self-hosted, harbor-srv]
-    continue-on-error: true
     if: ${{ always() && needs.download.result == 'success' }}
     steps:
       - name: Flash server

--- a/profile/airootfs/usr/local/sbin/harbor-deploy
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy
@@ -138,6 +138,9 @@ umount "$MOUNT_DIR"
 rmdir "$MOUNT_DIR"
 
 echo ""
-echo "=== Deploy complete — rebooting ==="
+echo "=== Deploy complete — rebooting in 10s ==="
 echo "New root written to ${TARGET_LABEL} (${TARGET_DEV})"
-reboot
+# Schedule reboot via a detached systemd timer so this script can exit 0 cleanly
+# before the machine goes down. The runner records the step as succeeded; the
+# verify job in the workflow then polls for the offline→online transition.
+systemd-run --on-active=10 systemctl reboot


### PR DESCRIPTION
## Problem

`harbor-deploy` ended with a bare `reboot`, which killed the GitHub Actions runner mid-job. GitHub interpreted the abrupt process death as a job failure even when the deploy completed cleanly. The workaround (`continue-on-error: true` on the flash job) suppressed the error so the workflow could continue, but the flash job still showed red in the UI and the overall workflow run was marked failed — every successful deploy looked like a failure.

## Fix

**`harbor-deploy`**: Replace `reboot` with `systemd-run --on-active=10 systemctl reboot`.

`systemd-run --on-active=10` creates a transient systemd timer that fires `systemctl reboot` 10 seconds after the script exits — completely outside the current process tree. `harbor-deploy` can then exit 0 cleanly, giving the runner time to record the step as succeeded before the machine goes down.

**`promotion.yml`**: Remove `continue-on-error: true` from the flash job.

With harbor-deploy exiting cleanly on success, the flash job completes green. The workaround is no longer needed. Removing it means real failures (image not found, missing partitions.conf, failed write, etc.) now correctly propagate as a workflow failure instead of being silently swallowed.

The `verify` job's offline→online poll is unchanged and remains the authoritative end-to-end success signal.

## Test plan

- [ ] Trigger `deploy` via the Promotion workflow
- [ ] Confirm the flash job completes **green** before the machine reboots
- [ ] Confirm the verify job detects offline → online transition as before
- [ ] Confirm the overall workflow run shows success end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)