### PR TITLE
fix(deploy): fix flash job failure and verify job 403

### DIFF
--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -134,9 +134,17 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && needs.flash.result != 'cancelled' && needs.flash.result != 'skipped' }}
     steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RUNNER_POLLER_APP_ID }}
+          private-key: ${{ secrets.RUNNER_POLLER_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Wait for runner to reboot and reconnect
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           OFFLINE_TIMEOUT=90
           ONLINE_TIMEOUT=300

--- a/profile/airootfs/usr/local/sbin/harbor-deploy
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy
@@ -138,9 +138,12 @@ umount "$MOUNT_DIR"
 rmdir "$MOUNT_DIR"
 
 echo ""
-echo "=== Deploy complete — rebooting in 10s ==="
+echo "=== Deploy complete — rebooting in 60s ==="
 echo "New root written to ${TARGET_LABEL} (${TARGET_DEV})"
 # Schedule reboot via a detached systemd timer so this script can exit 0 cleanly
 # before the machine goes down. The runner records the step as succeeded; the
 # verify job in the workflow then polls for the offline→online transition.
-systemd-run --on-active=10 systemctl reboot
+# --no-block: return immediately after creating the timer unit (do not wait for it to fire).
+# --on-active=60: 60s gives the runner enough time to finish job cleanup and report
+# success to GitHub before the machine goes down.
+systemd-run --no-block --on-active=60 /usr/bin/systemctl reboot


### PR DESCRIPTION
## Problem

Two issues remaining after PR #99:

**1. Timer too short** — `systemd-run --on-active=10` fired while the runner was still in the "Complete job" cleanup phase. The "Flash server" step succeeded (harbor-deploy exited 0), but the runner was killed before it could finalize job status with GitHub → overall job failure.

**2. Verify job 403** — the verify job called `repos/.../actions/runners` with `GITHUB_TOKEN`, which cannot hold the "Self-hosted runners" permission regardless of the `permissions:` block. Always 403.

Refs blouin-labs/issues#44

## Fix

**`harbor-deploy`**: add `--no-block` (guarantees the timer unit is created non-blocking) and increase delay from 10 s → 60 s, giving the runner 60 s to finish job cleanup before the machine goes down.

**`promotion.yml`**: generate a token from the existing `RUNNER_POLLER` GitHub App — same `actions/create-github-app-token@v1` pattern already in `select-runner.yml` — which holds the "Self-hosted runners" permission the runners API requires.

## Test plan

- [ ] Trigger `deploy` via the Promotion workflow
- [ ] Confirm flash job completes **green**
- [ ] Confirm verify job polls offline → online without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)