### PR TITLE
feat(profile): add compose-deploy SSH user for mooring_field stack deployment

### DIFF
--- a/profile/airootfs/etc/group
+++ b/profile/airootfs/etc/group
@@ -47,8 +47,9 @@ systemd-resolve:x:974:
 systemd-timesync:x:973:
 tss:x:972:
 uuidd:x:971:
-docker:x:970:runner
+docker:x:970:runner,compose-deploy
 alpm:x:969:
 rpc:x:32:
 rpcuser:x:34:
 runner:x:968:
+compose-deploy:x:966:

--- a/profile/airootfs/etc/passwd
+++ b/profile/airootfs/etc/passwd
@@ -18,3 +18,4 @@ alpm:x:969:969:Arch Linux Package Management:/:/usr/bin/nologin
 rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/usr/bin/nologin
 rpcuser:x:34:34:RPC Service User:/var/lib/nfs:/usr/bin/nologin
 runner:x:968:968:GitHub Actions Runner:/var/lib/runner:/usr/bin/nologin
+compose-deploy:x:966:966:Compose Deploy Runner:/var/lib/compose-deploy:/usr/bin/nologin

--- a/profile/airootfs/etc/shadow
+++ b/profile/airootfs/etc/shadow
@@ -1,2 +1,3 @@
 root::14871::::::
 runner:!*:::::::
+compose-deploy:!*:::::::

--- a/profile/airootfs/var/lib/compose-deploy/.ssh/authorized_keys
+++ b/profile/airootfs/var/lib/compose-deploy/.ssh/authorized_keys
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMwPnsYvcOEEmUPmVbokT1fL4fxfNFGYofQg+3AyEJK/ compose-deploy@harbor-srv

--- a/profile/profiledef.sh
+++ b/profile/profiledef.sh
@@ -20,6 +20,9 @@ file_permissions=(
   ["/usr/local/sbin/harbor-compose-ctl"]="0:0:750"
   ["/etc/sudoers.d/runner"]="0:0:440"
   ["/var/lib/runner"]="968:968:700"
+  ["/var/lib/compose-deploy"]="966:966:700"
+  ["/var/lib/compose-deploy/.ssh"]="966:966:700"
+  ["/var/lib/compose-deploy/.ssh/authorized_keys"]="966:966:600"
   ["/var/lib/krb5kdc"]="0:0:700"
 )
 


### PR DESCRIPTION
## Summary

- Adds `compose-deploy` system user (UID/GID 966) to the harbor_srv image
- Member of the `docker` group — can run `docker compose` without sudo
- SSH-only login with a dedicated key pair; no sudo whatsoever
- Used by mooring_field's `promotion.yml` to rsync stack files and run `docker compose up -d`

The private key is stored as `GH_COMPOSE_SSH_KEY` in `blouin-labs/mooring_field`. The NFS stacks directory at `/mnt/synology/harbor_srv/docker/` is world-writable so no NFS UID mapping is needed.

## Test plan

- [ ] Image builds successfully (CI on staging)
- [ ] After promotion/deploy: `ssh -i <compose-deploy-key> compose-deploy@harbor-srv "docker ps"` succeeds
- [ ] `ssh compose-deploy@harbor-srv "touch /mnt/synology/harbor_srv/docker/.test && rm /mnt/synology/harbor_srv/docker/.test"` succeeds
- [ ] `ssh compose-deploy@harbor-srv "sudo anything"` fails (no sudo)

Refs blouin-labs/issues#47

🤖 Generated with [Claude Code](https://claude.com/claude-code)