### PR TITLE
fix(ci): replace gh with curl in deploy fallback; update harbor-deploy path

### DIFF
--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -86,9 +86,11 @@ jobs:
             RUN_ID="${{ needs.promote.outputs.run_id }}"
           fi
           if [ -z "$RUN_ID" ]; then
-            RUN_ID=$(gh api \
-              "repos/${{ github.repository }}/actions/workflows/build.yml/runs?branch=staging&status=success&per_page=1" \
-              --jq '.workflow_runs[0].id')
+            RUN_ID=$(curl -sf \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/build.yml/runs?branch=staging&status=success&per_page=1" \
+              | jq -r '.workflow_runs[0].id')
           fi
           if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
             echo "ERROR: could not resolve a build artifact to deploy" >&2
@@ -127,7 +129,7 @@ jobs:
           # Do not use SETENV: or pass the variable inline (sudo VAR=val) — that
           # form requires SETENV: which broadens the attack surface to all env vars.
           KRB5_SECRETS_B64: ${{ secrets.KRB5_SECRETS_B64 }}
-        run: sudo /usr/local/sbin/harbor-deploy
+        run: sudo /usr/local/sbin/harbor-deploy.sh
 
   verify:
     needs: [flash]


### PR DESCRIPTION
## Summary

- Replaces `gh api` with `curl + jq` in the "Resolve artifact" fallback — `gh` is not installed on the self-hosted `harbor-srv` runner
- Updates the flash step to call `harbor-deploy.sh`, matching the sudoers whitelist after the recent `.sh` rename

The `deploy` action skips the `promote` job, so `needs.promote.outputs.run_id` is empty and the fallback is always hit. The `promote-and-deploy` action was unaffected because `promote` always runs and provides `run_id`.

Closes blouin-labs/issues#49

## Test plan

- [ ] Merge to staging
- [ ] Trigger a `deploy`-only promotion — "Resolve artifact" step should succeed and the full deploy should complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)