### PR TITLE
fix(deploy): reduce reboot timer from 60s to 5s

### DIFF
--- a/profile/airootfs/usr/local/sbin/harbor-deploy.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy.sh
@@ -140,17 +140,7 @@ rmdir "$MOUNT_DIR"
 echo ""
 echo "=== Deploy complete — rebooting in 5s ==="
 echo "New root written to ${TARGET_LABEL} (${TARGET_DEV})"
-# Reboot via a detached transient systemd timer so this script can exit 0 cleanly.
-#
-# --no-block is required: without it, systemd-run blocks until the spawned unit
-# finishes (i.e. until the machine is down), so harbor-deploy never exits and the
-# runner is killed before it can report success to GitHub.
-#
-# --on-active=5 gives the runner ~5 s after this script exits to POST its job
-# status to the GitHub API. In practice the API call takes 1-3 s; 5 s is
-# conservative enough to be safe without burning wall-clock time. The original
-# value was 60 s — set when --no-block was first added and 10 s proved tight —
-# but 60 s was never measured, just guessed. The verify job's offline→online
-# poll is the authoritative success signal; this timer only needs to outlast
-# the runner's cleanup window.
+# Defer reboot so this script exits 0 before the machine goes down.
+# --no-block: return immediately (without it, systemd-run waits and the runner is killed mid-report).
+# --on-active=5: 5s for the runner to POST job status to GitHub (~1-3s in practice).
 systemd-run --no-block --on-active=5 /usr/bin/systemctl reboot

--- a/profile/airootfs/usr/local/sbin/harbor-deploy.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy.sh
@@ -138,12 +138,19 @@ umount "$MOUNT_DIR"
 rmdir "$MOUNT_DIR"
 
 echo ""
-echo "=== Deploy complete — rebooting in 60s ==="
+echo "=== Deploy complete — rebooting in 5s ==="
 echo "New root written to ${TARGET_LABEL} (${TARGET_DEV})"
-# Schedule reboot via a detached systemd timer so this script can exit 0 cleanly
-# before the machine goes down. The runner records the step as succeeded; the
-# verify job in the workflow then polls for the offline→online transition.
-# --no-block: return immediately after creating the timer unit (do not wait for it to fire).
-# --on-active=60: 60s gives the runner enough time to finish job cleanup and report
-# success to GitHub before the machine goes down.
-systemd-run --no-block --on-active=60 /usr/bin/systemctl reboot
+# Reboot via a detached transient systemd timer so this script can exit 0 cleanly.
+#
+# --no-block is required: without it, systemd-run blocks until the spawned unit
+# finishes (i.e. until the machine is down), so harbor-deploy never exits and the
+# runner is killed before it can report success to GitHub.
+#
+# --on-active=5 gives the runner ~5 s after this script exits to POST its job
+# status to the GitHub API. In practice the API call takes 1-3 s; 5 s is
+# conservative enough to be safe without burning wall-clock time. The original
+# value was 60 s — set when --no-block was first added and 10 s proved tight —
+# but 60 s was never measured, just guessed. The verify job's offline→online
+# poll is the authoritative success signal; this timer only needs to outlast
+# the runner's cleanup window.
+systemd-run --no-block --on-active=5 /usr/bin/systemctl reboot


### PR DESCRIPTION
## Summary

- Reduces `--on-active=60` to `--on-active=5` in `harbor-deploy.sh`
- Expands the comment to document *why* each flag exists and the reasoning behind the 5s value, so the next person doesn't have to dig through git history

## Context

The 60s delay was never measured. It was added conservatively when `--no-block` was introduced (after 10s without `--no-block` proved too fast — but that failure was caused by the missing `--no-block`, not the 10s value). With `--no-block`, `systemd-run` returns immediately and harbor-deploy exits 0; the runner then has N seconds to POST job status to GitHub. That call takes 1-3s in practice, so 5s is safe.

The `systemd-run --no-block` mechanism itself is still required — a bare `systemctl reboot` kills the runner before it can report, which is what started this whole chain. Only the delay is reduced.

Refs blouin-labs/issues#48

## Test plan

- [ ] Run a `deploy` from the Promotion workflow and confirm the flash job reports success and the verify job sees the offline→online transition normally
- [ ] Confirm total deploy wall-clock time is reduced by ~55s

🤖 Generated with [Claude Code](https://claude.com/claude-code)