### PR TITLE
fix(build): remove deleted runner services from systemctl enable

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -136,8 +136,6 @@ arch-chroot "${WORK_DIR}/mnt" systemctl enable \
     docker \
     mnt-synology-harbor_srv.mount \
     systemd-bless-boot.service \
-    harbor-runner-bootstrap.service \
-    harbor-runner.service \
     harbor-compose.service \
     krb5-kdc.service \
     rpc-gssd.service


### PR DESCRIPTION
## Summary

- Removes `harbor-runner-bootstrap.service` and `harbor-runner.service` from the `systemctl enable` call in `build-image.sh`

These services were deleted by PR #102 but the build script still referenced them. Under `set -euo pipefail`, the failing `systemctl enable` exits the script after `locale-gen`, before `mkinitcpio -P` and image compression ever run.

Refs blouin-labs/issues#45

🤖 Generated with [Claude Code](https://claude.com/claude-code)