### PR TITLE
fix: harbor-runner bootstrap fixes

### DIFF
--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -107,6 +107,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ steps.artifact.outputs.run_id }}/artifacts" \
             | jq -r '.artifacts[] | select(.name | startswith("harbor_srv-root")) | .archive_download_url')
+          rm -rf /tmp/harbor-deploy/
           mkdir -p /tmp/harbor-deploy/
           curl -sL \
             -H "Authorization: Bearer $GH_TOKEN" \

--- a/profile/airootfs/etc/passwd
+++ b/profile/airootfs/etc/passwd
@@ -17,5 +17,5 @@ uuidd:x:971:971:UUID generator helper daemon:/var/lib/libuuid:/usr/bin/nologin
 alpm:x:969:969:Arch Linux Package Management:/:/usr/bin/nologin
 rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/usr/bin/nologin
 rpcuser:x:34:34:RPC Service User:/var/lib/nfs:/usr/bin/nologin
-gh-deploy:x:967:967:GitHub Deploy Runner:/var/lib/gh-deploy:/usr/bin/nologin
+gh-deploy:x:967:967:GitHub Deploy Runner:/var/lib/gh-deploy:/bin/bash
 compose-deploy:x:966:966:Compose Deploy Runner:/var/lib/compose-deploy:/usr/bin/nologin

--- a/profile/airootfs/var/lib/gh-deploy/.ssh/authorized_keys
+++ b/profile/airootfs/var/lib/gh-deploy/.ssh/authorized_keys
@@ -1,2 +1,2 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA4tAlDNa89dbJHreI8MYsauEzoGpsjct29i3EIbFTBZ gh-deploy@harbor-srv
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKay8OiLgfyKnGLwFlC+NvxJGgn4BCH3X1Fvf1a2VAs2 gh-deploy@harbor-srv
 


### PR DESCRIPTION
## Summary

- `fix(profile): rotate gh-deploy SSH public key` — new keypair; old key lost after flash
- `fix(ci): clear stale artifact dir before download` — `rm -rf /tmp/harbor-deploy/` before download to avoid unzip prompt on re-run (Closes blouin-labs/issues#57)
- `fix(profile): give gh-deploy a real shell for SCP/SSH command execution` — `/usr/bin/nologin` blocks `scp` and remote command execution; access is restricted via sudoers

## Test plan

- [ ] Promotion workflow completes without artifact conflict error
- [ ] SCP transfer to harbor-srv succeeds
- [ ] gh-deploy SSH access still restricted to sudoers-listed commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)