### PR TITLE
fix(ci): fix shellcheck on DinD runner, harbor-runner restart, and ghcr.io auth

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,24 +33,19 @@ jobs:
               - '**.md'
               - '.vale.ini'
 
-  select-runner:
-    uses: ./.github/workflows/select-runner.yml
-    secrets: inherit
-
   shellcheck:
-    needs: [changes, select-runner]
+    needs: changes
     if: ${{ needs.changes.outputs.scripts == 'true' }}
-    runs-on: ${{ fromJSON(needs.select-runner.outputs.runner) }}
+    # harbor-srv-docker (DinD) cannot start nested containers due to /proc mount
+    # restrictions — forced to wsl-docker-runner until blouin-labs/issues#63 is resolved.
+    runs-on: [self-hosted, wsl-docker-runner]
     container:
-      # archlinux/archlinux:latest — pinned digest matches ARCH_SNAPSHOT in build.yml
-      image: archlinux/archlinux@sha256:0e2b66488c60a96c65041cde5e754957a880b760dd4f00865ed09c131a51cd44
+      image: ubuntu:latest
     steps:
       - uses: actions/checkout@v5
 
       - name: Install shellcheck
-        run: |
-          pacman -Sy --needed --noconfirm archlinux-keyring
-          pacman --noconfirm -Syu --needed shellcheck
+        run: apt-get update -qq && apt-get install -y shellcheck
 
       - name: Shellcheck
         run: find . -name "*.sh" -exec shellcheck {} +

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -134,7 +134,8 @@ jobs:
           # arbitrary variables into the root process.
           KRB5_SECRETS_B64: ${{ secrets.KRB5_SECRETS_B64 }}
           RUNNER_ENV_B64: ${{ secrets.RUNNER_ENV_B64 }}
-        run: ssh -o SendEnv=KRB5_SECRETS_B64 -o SendEnv=RUNNER_ENV_B64 harbor-srv sudo /usr/local/sbin/harbor-deploy.sh
+          GHIO_PULLER_KEY: ${{ secrets.GHIO_PULLER_KEY }}
+        run: ssh -o SendEnv=KRB5_SECRETS_B64 -o SendEnv=RUNNER_ENV_B64 -o SendEnv=GHIO_PULLER_KEY harbor-srv sudo /usr/local/sbin/harbor-deploy.sh
 
   verify:
     needs: [flash]

--- a/profile/airootfs/etc/harbor-runner/compose.yaml
+++ b/profile/airootfs/etc/harbor-runner/compose.yaml
@@ -7,7 +7,6 @@ services:
   runner:
     image: ghcr.io/blouin-labs/harbor-runner:latest
     container_name: harbor-runner
-    restart: unless-stopped
     privileged: true
     # Explicit DNS: the host resolv.conf is empty (systemd-resolved stub), so Docker's
     # embedded DNS for custom bridge networks has no upstream to forward to.

--- a/profile/airootfs/etc/ssh/sshd_config.d/50-harbor-deploy.conf
+++ b/profile/airootfs/etc/ssh/sshd_config.d/50-harbor-deploy.conf
@@ -1,3 +1,3 @@
 # Allow gh-deploy to forward secrets via SSH SendEnv.
 # This keeps secrets out of the SSH command line and process list.
-AcceptEnv KRB5_SECRETS_B64 RUNNER_ENV_B64
+AcceptEnv KRB5_SECRETS_B64 RUNNER_ENV_B64 GHIO_PULLER_KEY

--- a/profile/airootfs/etc/sudoers.d/gh-deploy
+++ b/profile/airootfs/etc/sudoers.d/gh-deploy
@@ -1,7 +1,7 @@
 # Whitelist only the secrets harbor-deploy.sh needs — SETENV: was avoided because
 # it would allow the runner to inject arbitrary variables (LD_PRELOAD, PATH, etc.)
 # into the root process, enabling code injection via child processes.
-Defaults!/usr/local/sbin/harbor-deploy.sh env_keep+="KRB5_SECRETS_B64 RUNNER_ENV_B64"
+Defaults!/usr/local/sbin/harbor-deploy.sh env_keep+="KRB5_SECRETS_B64 RUNNER_ENV_B64 GHIO_PULLER_KEY"
 gh-deploy ALL=(root) NOPASSWD: /usr/local/sbin/harbor-deploy.sh
 gh-deploy ALL=(root) NOPASSWD: /usr/local/sbin/harbor-compose-ctl.sh rescan
 gh-deploy ALL=(root) NOPASSWD: /usr/local/sbin/harbor-compose-ctl.sh update

--- a/profile/airootfs/etc/systemd/system/ghio-puller-login.service
+++ b/profile/airootfs/etc/systemd/system/ghio-puller-login.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Authenticate Docker with ghcr.io via GitHub App token
+Before=harbor-runner.service
+After=network-online.target docker.service
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/ghio-puller-login.sh

--- a/profile/airootfs/etc/systemd/system/harbor-runner.service
+++ b/profile/airootfs/etc/systemd/system/harbor-runner.service
@@ -5,10 +5,11 @@ Requires=docker.service
 Wants=network-online.target
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=docker compose -f /etc/harbor-runner/compose.yaml up -d
+Type=exec
+ExecStart=docker compose -f /etc/harbor-runner/compose.yaml up --remove-orphans
 ExecStop=docker compose -f /etc/harbor-runner/compose.yaml down
+Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/profile/airootfs/etc/systemd/system/harbor-runner.service
+++ b/profile/airootfs/etc/systemd/system/harbor-runner.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=GitHub Actions Docker runner (harbor-srv-docker)
-After=docker.service network-online.target
-Requires=docker.service
+After=docker.service network-online.target ghio-puller-login.service
+Requires=docker.service ghio-puller-login.service
 Wants=network-online.target
 
 [Service]

--- a/profile/airootfs/usr/local/sbin/ghio-puller-login.sh
+++ b/profile/airootfs/usr/local/sbin/ghio-puller-login.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# ghio-puller-login — Authenticate Docker with ghcr.io using a short-lived
+# GitHub App installation token. Runs as a systemd oneshot before
+# harbor-runner.service so the runner image can be pulled on boot.
+#
+set -euo pipefail
+
+APP_ID=3258342
+KEY_FILE=/etc/ghio-puller/private-key.pem
+
+if [ ! -f "$KEY_FILE" ]; then
+    echo "ghio-puller-login: ${KEY_FILE} not found — was GHIO_PULLER_KEY injected at deploy time?" >&2
+    exit 1
+fi
+
+# base64url-encode stdin (no padding, + → -, / → _).
+b64url() { base64 -w0 | tr '+/' '-_' | tr -d '='; }
+
+now=$(date +%s)
+header=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)
+payload=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((now - 60))" "$((now + 600))" "$APP_ID" | b64url)
+sig=$(printf '%s.%s' "$header" "$payload" | openssl dgst -sha256 -sign "$KEY_FILE" | b64url)
+jwt="${header}.${payload}.${sig}"
+
+# Resolve installation ID dynamically — no hardcoded config needed.
+install_id=$(curl -sf \
+    -H "Authorization: Bearer ${jwt}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/app/installations \
+    | jq -r '.[] | select(.account.login == "blouin-labs") | .id')
+
+if [ -z "$install_id" ]; then
+    echo "ghio-puller-login: no blouin-labs installation found for app ${APP_ID}" >&2
+    exit 1
+fi
+
+token=$(curl -sf -X POST \
+    -H "Authorization: Bearer ${jwt}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/app/installations/${install_id}/access_tokens" \
+    | jq -r '.token')
+
+if [ -z "$token" ] || [ "$token" = "null" ]; then
+    echo "ghio-puller-login: failed to obtain installation access token" >&2
+    exit 1
+fi
+
+echo "$token" | docker login ghcr.io -u x-access-token --password-stdin
+echo "ghio-puller-login: authenticated with ghcr.io"

--- a/profile/airootfs/usr/local/sbin/harbor-deploy.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy.sh
@@ -121,6 +121,19 @@ else
     echo "WARNING: RUNNER_ENV_B64 not set — harbor-runner will not start after reboot" >&2
 fi
 
+# --- Inject ghio-puller private key ---
+if [ -n "${GHIO_PULLER_KEY:-}" ]; then
+    echo ":: Injecting ghio-puller private key..."
+    mkdir -p "${MOUNT_DIR}/etc/ghio-puller"
+    chmod 700 "${MOUNT_DIR}/etc/ghio-puller"
+    printf '%s' "$GHIO_PULLER_KEY" > "${MOUNT_DIR}/etc/ghio-puller/private-key.pem"
+    chmod 600 "${MOUNT_DIR}/etc/ghio-puller/private-key.pem"
+    unset GHIO_PULLER_KEY
+    echo ":: ghio-puller private key injected."
+else
+    echo "WARNING: GHIO_PULLER_KEY not set — ghcr.io docker login will fail on boot" >&2
+fi
+
 ESP_MOUNT=$(findmnt -n -o TARGET /boot/efi 2>/dev/null || echo "")
 if [ -z "$ESP_MOUNT" ]; then
     mkdir -p /boot/efi

--- a/profile/profiledef.sh
+++ b/profile/profiledef.sh
@@ -17,6 +17,7 @@ file_permissions=(
   ["/usr/local/bin/harbor-compose-update.sh"]="0:0:750"
   ["/usr/local/sbin/harbor-deploy.sh"]="0:0:750"
   ["/usr/local/sbin/harbor-compose-ctl.sh"]="0:0:750"
+  ["/usr/local/sbin/ghio-puller-login.sh"]="0:0:750"
   ["/etc/harbor-runner"]="0:0:755"
   ["/etc/harbor-runner/compose.yaml"]="0:0:644"
   ["/etc/sudoers.d/gh-deploy"]="0:0:440"


### PR DESCRIPTION
## Summary

- Switch \`shellcheck\` from \`archlinux/archlinux\` to \`ubuntu:latest\` container on \`wsl-docker-runner\`; \`harbor-srv-docker\` (DinD) cannot mount \`/proc\` for nested containers (blouin-labs/issues#63). Hardcoded to \`wsl-docker-runner\` for now — blouin-labs/issues#64 tracks restoring \`select-runner\`.
- Change \`harbor-runner.service\` from \`Type=oneshot\` to \`Type=exec\` with foreground \`docker compose up\`, so systemd monitors and restarts the runner on failure (\`Restart=on-failure\`, \`RestartSec=30\`). Remove \`restart: unless-stopped\` from \`compose.yaml\` — systemd is sole restart owner.
- Add \`ghio-puller-login.service\` — a systemd oneshot that runs before \`harbor-runner.service\` and authenticates Docker with \`ghcr.io\` using a short-lived GitHub App installation token, so the runner image can be pulled on a fresh boot. Private key injected at deploy time via \`GHIO_PULLER_KEY\`.

Closes blouin-labs/issues#56
Closes blouin-labs/issues#58
Closes blouin-labs/issues#59

## Test plan

- [ ] \`shellcheck\` passes on a PR touching a \`.sh\` file (runs in \`ubuntu:latest\` on \`wsl-docker-runner\`)
- [ ] After promotion: \`systemctl restart harbor-runner\` recovers automatically (no manual \`docker compose up -d\`)
- [ ] After promotion on a fresh boot: \`ghio-puller-login.service\` succeeds and \`harbor-runner\` comes online

🤖 Generated with [Claude Code](https://claude.com/claude-code)