### PR TITLE
fix(ci): create missing /dev/loop* nodes before losetup in containerized builds

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -49,6 +49,13 @@ echo ":: Creating ${ROOT_SIZE} raw image..."
 truncate -s "$ROOT_SIZE" "${WORK_DIR}/${IMAGE_NAME}"
 mkfs.ext4 -F -L harbor_root "${WORK_DIR}/${IMAGE_NAME}"
 
+# In containerized builds, /dev/loop* nodes may not be pre-populated.
+# Create any missing ones so losetup --find can use them.
+for _i in $(seq 0 7); do
+    [ -e "/dev/loop${_i}" ] || mknod -m 660 "/dev/loop${_i}" b 7 "${_i}"
+done
+unset _i
+
 LOOP_DEV=$(losetup --find --show "${WORK_DIR}/${IMAGE_NAME}")
 echo ":: Loop device: ${LOOP_DEV}"
 mount "$LOOP_DEV" "${WORK_DIR}/mnt"


### PR DESCRIPTION
## Summary

- `losetup --find --show` allocates a loop device slot at the kernel level but fails because the corresponding `/dev/loop*` device node doesn't exist inside the nested Archlinux build container (harbor-srv-docker DinD → archlinux container)
- Fix: create loop device nodes 0-7 if missing before calling `losetup`, using `mknod b 7 N` (the standard loop device major number)
- No-op on bare metal where the nodes already exist

## Test plan

- [ ] Build workflow on staging succeeds past the `losetup` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)