### PR TITLE
fix(ci): use dind-runner image instead of harbor-runner in compose.yaml

### DIFF
--- a/profile/airootfs/etc/harbor-runner/compose.yaml
+++ b/profile/airootfs/etc/harbor-runner/compose.yaml
@@ -5,7 +5,7 @@ name: harbor-runner
 
 services:
   runner:
-    image: ghcr.io/blouin-labs/harbor-runner:latest
+    image: ghcr.io/blouin-labs/dind-runner:latest
     container_name: harbor-runner
     privileged: true
     # Explicit DNS: the host resolv.conf is empty (systemd-resolved stub), so Docker's


### PR DESCRIPTION
Corrects the image reference in `compose.yaml` from `harbor-runner:latest` (stale/non-existent) to `dind-runner:latest`, which is what `blouin-labs/dind-runner` actually publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)