### PR TITLE
fix(profile): add .sh extension to exec targets in harbor-compose-ctl.sh

### DIFF
--- a/profile/airootfs/usr/local/sbin/ghio-puller-login.sh
+++ b/profile/airootfs/usr/local/sbin/ghio-puller-login.sh
@@ -17,5 +17,5 @@ if [ ! -f "$PAT_FILE" ]; then
     exit 1
 fi
 
-cat "$PAT_FILE" | docker login ghcr.io -u x-access-token --password-stdin
+docker login ghcr.io -u x-access-token --password-stdin < "$PAT_FILE"
 echo "ghio-puller-login: authenticated with ghcr.io"

--- a/profile/airootfs/usr/local/sbin/harbor-compose-ctl.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-compose-ctl.sh
@@ -14,10 +14,10 @@ ACTION="${1:-}"
 
 case "${ACTION}" in
     rescan)
-        exec /usr/local/bin/harbor-compose-up
+        exec /usr/local/bin/harbor-compose-up.sh
         ;;
     update)
-        exec /usr/local/bin/harbor-compose-update
+        exec /usr/local/bin/harbor-compose-update.sh
         ;;
     stop)
         exec systemctl stop harbor-compose.service

--- a/profile/airootfs/usr/local/sbin/harbor-deploy.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy.sh
@@ -17,7 +17,7 @@ cleanup() {
     if [ -n "$MOUNT_DIR" ] && mountpoint -q "$MOUNT_DIR" 2>/dev/null; then
         umount -R "$MOUNT_DIR" 2>/dev/null || true
     fi
-    [ -n "$MOUNT_DIR" ] && rmdir "$MOUNT_DIR" 2>/dev/null || true
+    if [ -n "$MOUNT_DIR" ]; then rmdir "$MOUNT_DIR" 2>/dev/null || true; fi
 }
 trap cleanup EXIT
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,7 +15,7 @@ cleanup() {
     if [ -n "$MOUNT_DIR" ] && mountpoint -q "$MOUNT_DIR" 2>/dev/null; then
         umount -R "$MOUNT_DIR" 2>/dev/null || true
     fi
-    [ -n "$MOUNT_DIR" ] && rmdir "$MOUNT_DIR" 2>/dev/null || true
+    if [ -n "$MOUNT_DIR" ]; then rmdir "$MOUNT_DIR" 2>/dev/null || true; fi
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Summary

- Fixes `harbor-compose-ctl.sh rescan` and `update` commands exiting 127 on the live system
- The exec targets were missing the `.sh` suffix introduced in 52ed055

Closes blouin-labs/issues#75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)