### PR TITLE
harbor-deploy: unmount target partition if already mounted before flashing

### DIFF
--- a/profile/airootfs/usr/local/sbin/harbor-deploy.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy.sh
@@ -72,6 +72,13 @@ TARGET_ENTRY="${TARGET_ENTRY_BASE}+${BOOT_TRIES}.conf"
 
 echo ":: Target: ${TARGET_LABEL} (${TARGET_DEV})"
 
+# Ensure the target partition is not mounted before writing to it.
+TARGET_MOUNT=$(findmnt -n -o TARGET "$TARGET_DEV" 2>/dev/null || true)
+if [ -n "$TARGET_MOUNT" ]; then
+    echo ":: Unmounting ${TARGET_DEV} from ${TARGET_MOUNT}..."
+    umount "$TARGET_DEV"
+fi
+
 echo ":: Decompressing and writing image..."
 zstd -d "$IMAGE" --stdout | dd of="$TARGET_DEV" bs=4M conv=fsync status=progress
 sync


### PR DESCRIPTION
Fixes blouin-labs/issues#76.

## Problem

`harbor-deploy.sh` has no guard against the target partition being already mounted. During a manual bootstrap, operators mount the inactive partition (e.g. `/dev/nvme0n1p3` at `/mnt/rootb`) to copy secrets, and may leave it mounted. The next Promotion run then fails:

- `e2fsck` aborts with `Cannot continue, aborting. /dev/nvme0n1p3 is mounted.`
- `resize2fs` falls back to online resize and fails with `Bad message`

## Fix

Detect and unmount the target partition before `dd`/`e2fsck`/`resize2fs`. The check is a no-op when the partition is not mounted.

```
:: Unmounting /dev/nvme0n1p3 from /mnt/rootb...
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)