### PR TITLE
fix(ci): add trailing newline to PEM key writes in harbor-deploy.sh

### DIFF
--- a/profile/airootfs/usr/local/sbin/harbor-deploy.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy.sh
@@ -129,7 +129,7 @@ fi
 if [ -n "${RUNNER_REG_APP_KEY:-}" ]; then
     echo ":: Injecting runner registration App private key..."
     mkdir -p "${MOUNT_DIR}/etc/harbor-runner"
-    printf '%s' "$RUNNER_REG_APP_KEY" > "${MOUNT_DIR}/etc/harbor-runner/runner-reg-key.pem"
+    printf '%s\n' "$RUNNER_REG_APP_KEY" > "${MOUNT_DIR}/etc/harbor-runner/runner-reg-key.pem"
     chmod 600 "${MOUNT_DIR}/etc/harbor-runner/runner-reg-key.pem"
     unset RUNNER_REG_APP_KEY
     echo ":: Runner registration App private key injected."
@@ -141,7 +141,7 @@ fi
 if [ -n "${GH_DEPLOY_SSH_KEY:-}" ]; then
     echo ":: Injecting gh-deploy SSH private key..."
     mkdir -p "${MOUNT_DIR}/etc/harbor-runner"
-    printf '%s' "$GH_DEPLOY_SSH_KEY" > "${MOUNT_DIR}/etc/harbor-runner/gh-deploy-key"
+    printf '%s\n' "$GH_DEPLOY_SSH_KEY" > "${MOUNT_DIR}/etc/harbor-runner/gh-deploy-key"
     chmod 600 "${MOUNT_DIR}/etc/harbor-runner/gh-deploy-key"
     unset GH_DEPLOY_SSH_KEY
     echo ":: gh-deploy SSH private key injected."


### PR DESCRIPTION
## Summary

- `harbor-deploy.sh` wrote PEM key files with `printf '%s'`, which omits the trailing newline that OpenSSH libcrypto requires
- This caused `scp`/`ssh` in the `download` job to fail with `error in libcrypto` on every promotion after a flash
- Fix: change both key writes to `printf '%s\n'`

The `GHIO_PULLER_PAT` and `KRB5_SECRETS_B64` writes are intentionally unchanged (Docker stdin trims whitespace; base64 pipe must not gain an extra byte).

## Workaround applied

Appended the missing newline directly on harbor-srv and restarted `harbor-runner.service` — runner is back online.

## Test plan

- [ ] PR CI (shellcheck) passes
- [ ] After merge, run promotion — `download` and `flash` jobs should succeed
- [ ] After the next flash, verify `ssh-keygen -y -f /etc/harbor-runner/gh-deploy-key` succeeds without error on the live server

Closes blouin-labs/issues#77

🤖 Generated with [Claude Code](https://claude.com/claude-code)