### PR TITLE
fix(ci): derive gh-deploy authorized_keys from secret at deploy time

### DIFF
--- a/profile/airootfs/usr/local/sbin/harbor-deploy.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy.sh
@@ -137,14 +137,21 @@ else
     echo "WARNING: RUNNER_REG_APP_KEY not set — harbor-runner cannot self-register" >&2
 fi
 
-# --- Inject gh-deploy SSH private key ---
+# --- Inject gh-deploy SSH private key and update authorized_keys ---
 if [ -n "${GH_DEPLOY_SSH_KEY:-}" ]; then
     echo ":: Injecting gh-deploy SSH private key..."
     mkdir -p "${MOUNT_DIR}/etc/harbor-runner"
     printf '%s\n' "$GH_DEPLOY_SSH_KEY" > "${MOUNT_DIR}/etc/harbor-runner/gh-deploy-key"
     chmod 600 "${MOUNT_DIR}/etc/harbor-runner/gh-deploy-key"
+
+    echo ":: Updating gh-deploy authorized_keys..."
+    mkdir -p "${MOUNT_DIR}/var/lib/gh-deploy/.ssh"
+    ssh-keygen -y -f "${MOUNT_DIR}/etc/harbor-runner/gh-deploy-key" \
+        > "${MOUNT_DIR}/var/lib/gh-deploy/.ssh/authorized_keys"
+    chmod 600 "${MOUNT_DIR}/var/lib/gh-deploy/.ssh/authorized_keys"
+
     unset GH_DEPLOY_SSH_KEY
-    echo ":: gh-deploy SSH private key injected."
+    echo ":: gh-deploy SSH private key and authorized_keys injected."
 else
     echo "WARNING: GH_DEPLOY_SSH_KEY not set — CI deploy jobs will fail" >&2
 fi

--- a/profile/airootfs/var/lib/gh-deploy/.ssh/authorized_keys
+++ b/profile/airootfs/var/lib/gh-deploy/.ssh/authorized_keys
@@ -1,2 +1,0 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKay8OiLgfyKnGLwFlC+NvxJGgn4BCH3X1Fvf1a2VAs2 gh-deploy@harbor-srv
-


### PR DESCRIPTION
## Summary

- The \`gh-deploy\` user's \`authorized_keys\` was hardcoded in the golden image; rotating \`GH_DEPLOY_SSH_KEY\` in Actions without rebuilding caused a permanent \`Permission denied (publickey)\` on every promotion
- \`harbor-deploy.sh\` now derives the public key via \`ssh-keygen -y\` from the injected private key and writes it to \`authorized_keys\` on the target partition — the two are always in sync
- Hardcoded public key removed from \`profile/airootfs/var/lib/gh-deploy/.ssh/authorized_keys\` (file is now empty; contents are always written at deploy time)

## Test plan

- [ ] shellcheck passes
- [ ] Re-run promotion — \`scp\` in the \`download\` job should succeed
- [ ] After next flash, confirm \`ssh-keygen -y -f /etc/harbor-runner/gh-deploy-key\` matches \`cat /var/lib/gh-deploy/.ssh/authorized_keys\` on the server

Closes blouin-labs/issues#78

🤖 Generated with [Claude Code](https://claude.com/claude-code)