### PR TITLE
fix(ci): align harbor-deploy.sh var names with org secret/var names

### DIFF
--- a/profile/airootfs/usr/local/sbin/harbor-deploy.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy.sh
@@ -21,8 +21,8 @@ RUNNER_REG_APP_ID=""  ; if [ -f "${SECRETS_DIR}/runner-reg-app-id"  ]; then RUNN
 GH_DEPLOY_SSH_KEY=""  ; if [ -f "${SECRETS_DIR}/gh-deploy-key"      ]; then GH_DEPLOY_SSH_KEY=$(  cat "${SECRETS_DIR}/gh-deploy-key");      fi
 GHIO_PULLER_PAT=""    ; if [ -f "${SECRETS_DIR}/ghio-puller-pat"    ]; then GHIO_PULLER_PAT=$(    cat "${SECRETS_DIR}/ghio-puller-pat");    fi
 DEPLOY_RUN_ID=""      ; if [ -f "${SECRETS_DIR}/run-id"             ]; then DEPLOY_RUN_ID=$(      cat "${SECRETS_DIR}/run-id");             fi
-HARBOR_BOOT_APP_KEY=""; if [ -f "${SECRETS_DIR}/boot-app-key"       ]; then HARBOR_BOOT_APP_KEY=$(cat "${SECRETS_DIR}/boot-app-key");       fi
-HARBOR_BOOT_APP_ID="" ; if [ -f "${SECRETS_DIR}/boot-app-id"        ]; then HARBOR_BOOT_APP_ID=$( cat "${SECRETS_DIR}/boot-app-id");        fi
+HARBOR_BOOT_REPORTER_KEY=""; if [ -f "${SECRETS_DIR}/boot-app-key"       ]; then HARBOR_BOOT_REPORTER_KEY=$(cat "${SECRETS_DIR}/boot-app-key");       fi
+HARBOR_BOOT_REPORTER_APP_ID="" ; if [ -f "${SECRETS_DIR}/boot-app-id"        ]; then HARBOR_BOOT_REPORTER_APP_ID=$( cat "${SECRETS_DIR}/boot-app-id");        fi
 rm -rf "$SECRETS_DIR"
 
 cleanup() {
@@ -192,12 +192,12 @@ if [ -n "${DEPLOY_RUN_ID:-}" ]; then
     chmod 600 "${MOUNT_DIR}/etc/harbor/last-deploy-context"
 fi
 
-if [ -n "${HARBOR_BOOT_APP_KEY:-}" ] && [ -n "${HARBOR_BOOT_APP_ID:-}" ]; then
+if [ -n "${HARBOR_BOOT_REPORTER_KEY:-}" ] && [ -n "${HARBOR_BOOT_REPORTER_APP_ID:-}" ]; then
     echo ":: Injecting harbor-boot-reporter App credentials..."
-    printf '%s\n' "$HARBOR_BOOT_APP_KEY" > "${MOUNT_DIR}/etc/harbor/boot-app-key"
+    printf '%s\n' "$HARBOR_BOOT_REPORTER_KEY" > "${MOUNT_DIR}/etc/harbor/boot-app-key"
     chmod 600 "${MOUNT_DIR}/etc/harbor/boot-app-key"
-    printf '%s'  "$HARBOR_BOOT_APP_ID"  > "${MOUNT_DIR}/etc/harbor/boot-app-id"
-    unset HARBOR_BOOT_APP_KEY HARBOR_BOOT_APP_ID
+    printf '%s'  "$HARBOR_BOOT_REPORTER_APP_ID"  > "${MOUNT_DIR}/etc/harbor/boot-app-id"
+    unset HARBOR_BOOT_REPORTER_KEY HARBOR_BOOT_REPORTER_APP_ID
     echo ":: harbor-boot-reporter App credentials injected."
 fi
 


### PR DESCRIPTION
Renames internal shell variables in `harbor-deploy.sh` to match the org-level secret/var names for consistency:

- `HARBOR_BOOT_APP_KEY` → `HARBOR_BOOT_REPORTER_KEY`
- `HARBOR_BOOT_APP_ID` → `HARBOR_BOOT_REPORTER_APP_ID`

Refs blouin-labs/issues#79