### PR TITLE
fix(image): enable systemd-timesyncd to prevent JWT rejection on first boot

### DIFF
--- a/profile/airootfs/etc/systemd/system/sysinit.target.wants/systemd-timesyncd.service
+++ b/profile/airootfs/etc/systemd/system/sysinit.target.wants/systemd-timesyncd.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/systemd-timesyncd.service


### PR DESCRIPTION
## Summary

- `systemd-timesyncd` was disabled in the image — `systemctl preset` runs during `pacstrap` but fails silently in the build chroot (systemd not PID 1), so the enable symlink was never created
- On first boot, `harbor-runner` started before the clock was NTP-synced; GitHub rejected the App JWT with `'exp' is too far in the future`
- Fix: add a pre-baked symlink in `sysinit.target.wants/`, matching the pattern used by [archiso/releng](https://github.com/archlinux/archiso/tree/52bf735fc434aa0bd9d04433dcb70a1313856a1e/configs/releng/airootfs/etc/systemd/system/sysinit.target.wants)

Closes blouin-labs/issues#80

## Test plan

- [ ] CI build succeeds on push to staging
- [ ] After promote-and-deploy: `ssh root@192.168.1.5 systemctl is-enabled systemd-timesyncd` → `enabled`
- [ ] After reboot: `timedatectl` → `System clock synchronized: yes` before runner comes online

🤖 Generated with [Claude Code](https://claude.com/claude-code)