### PR TITLE
fix(ci): fetch deploy script via API instead of checkout

### DIFF
--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -128,8 +128,6 @@ jobs:
     outputs:
       target_label: ${{ steps.target.outputs.target_label }}
     steps:
-      - uses: actions/checkout@v4
-
       - name: Determine target partition
         id: target
         run: |
@@ -140,10 +138,14 @@ jobs:
           echo "target_label=${LABEL}" >> "$GITHUB_OUTPUT"
 
       - name: Upload deploy script
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          scp profile/airootfs/usr/local/sbin/harbor-deploy.sh \
-            harbor-srv:/var/lib/gh-deploy/harbor-deploy-staged.sh
+          gh api "repos/${{ github.repository }}/contents/profile/airootfs/usr/local/sbin/harbor-deploy.sh?ref=${{ github.sha }}" \
+            --jq '.content' | base64 -d > /tmp/harbor-deploy-staged.sh
+          scp /tmp/harbor-deploy-staged.sh harbor-srv:/var/lib/gh-deploy/harbor-deploy-staged.sh
           ssh harbor-srv chmod +x /var/lib/gh-deploy/harbor-deploy-staged.sh
+          rm -f /tmp/harbor-deploy-staged.sh
 
       - name: Stage secrets
         env:


### PR DESCRIPTION
## Summary

- Replace `actions/checkout@v4` in the flash job with a `gh api` call to fetch just `harbor-deploy.sh`
- The self-hosted runner fails checkout with `EACCES: permission denied` when cleaning the workspace from previous runs
- We only need the one file — fetching it from the API pinned to `github.sha` is simpler and avoids the workspace issue

Fixes the flash failure from the previous deploy attempt.

## Test plan

- [ ] Merge and re-run promote-and-deploy — flash job should pass the "Upload deploy script" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)