### PR TITLE
fix(ci): use curl for deploy script fetch and validate non-empty

### DIFF
--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -141,8 +141,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api "repos/${{ github.repository }}/contents/profile/airootfs/usr/local/sbin/harbor-deploy.sh?ref=${{ github.sha }}" \
-            --jq '.content' | base64 -d > /tmp/harbor-deploy-staged.sh
+          curl -sf \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/contents/profile/airootfs/usr/local/sbin/harbor-deploy.sh?ref=${{ github.sha }}" \
+            | jq -r '.content' | base64 -d > /tmp/harbor-deploy-staged.sh
+          if [ ! -s /tmp/harbor-deploy-staged.sh ]; then
+            echo "ERROR: failed to fetch harbor-deploy.sh from API" >&2
+            exit 1
+          fi
           scp /tmp/harbor-deploy-staged.sh harbor-srv:/var/lib/gh-deploy/harbor-deploy-staged.sh
           ssh harbor-srv chmod +x /var/lib/gh-deploy/harbor-deploy-staged.sh
           rm -f /tmp/harbor-deploy-staged.sh


### PR DESCRIPTION
## Summary

- Switch deploy script fetch from `gh api` to `curl` — matches the pattern used by the download job and avoids issues with `gh` CLI availability on the self-hosted runner
- Add a non-empty file check (`-s`) to fail fast if the API fetch returns nothing, preventing a silent no-op deploy (0-byte script exits 0, no flash, no reboot)

## Root cause

The previous deploy ran a 0-byte `harbor-deploy-staged.sh` because `gh api` silently failed on the self-hosted runner, producing no output. The pipeline didn't catch it because pipe failures aren't fatal in GitHub Actions run blocks by default.

## Test plan

- [ ] Merge and deploy — flash job should take minutes (not 6 seconds) and server should reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)