### PR TITLE
fix(ci): poll HARBOR_BOOT_LAST with App token in verify step

### DIFF
--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -192,18 +192,42 @@ jobs:
     steps:
       - name: Verify root partition
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HARBOR_BOOT_APP_KEY: ${{ secrets.HARBOR_BOOT_REPORTER_KEY }}
+          HARBOR_BOOT_APP_ID: ${{ vars.HARBOR_BOOT_REPORTER_APP_ID }}
         run: |
           EXPECTED="${{ needs.flash.outputs.target_label }}"
           RUN_ID="${{ github.run_id }}"
 
+          KEY_FILE=$(mktemp)
+          printf '%s' "$HARBOR_BOOT_APP_KEY" > "$KEY_FILE"
+          NOW=$(date +%s)
+          HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
+          PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' $((NOW - 60)) $((NOW + 600)) "$HARBOR_BOOT_APP_ID" \
+                    | base64 -w0 | tr '+/' '-_' | tr -d '=')
+          SIG=$(printf '%s.%s' "$HEADER" "$PAYLOAD" \
+                | openssl dgst -sha256 -sign "$KEY_FILE" \
+                | base64 -w0 | tr '+/' '-_' | tr -d '=')
+          JWT="${HEADER}.${PAYLOAD}.${SIG}"
+          rm -f "$KEY_FILE"
+
+          INSTALL_ID=$(curl -sf \
+            -H "Authorization: Bearer $JWT" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/installation" | jq -r '.id')
+          TOKEN=$(curl -sf \
+            -X POST \
+            -H "Authorization: Bearer $JWT" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations/${INSTALL_ID}/access_tokens" | jq -r '.token')
+
           echo "Polling HARBOR_BOOT_LAST for run ${RUN_ID}..."
           RESULT=""
           for _ in $(seq 1 120); do
-            RESULT=$(gh api \
-              "repos/${{ github.repository }}/actions/variables/HARBOR_BOOT_LAST" \
-              --jq '.value' 2>/dev/null || echo "")
-            echo "Poll #${_}: RESULT='${RESULT}'"
+            RESULT=$(curl -sf \
+              -H "Authorization: Bearer $TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/variables/HARBOR_BOOT_LAST" \
+              | jq -r '.value' 2>/dev/null || echo "")
             RESULT_RUN="${RESULT%%:*}"
             if [ "$RESULT_RUN" = "$RUN_ID" ]; then break; fi
             sleep 5


### PR DESCRIPTION
`GITHUB_TOKEN` gets a 403 on the variables endpoint ("Resource not accessible by integration"), confirmed via debug logging added in afea443. The `--jq '.value'` on the error JSON silently produces the full object (not empty string), so `|| echo ""` never fires and the loop never breaks.

Fix: generate an App installation token from `harbor-boot-reporter` and use it for the `curl` poll, matching the credential the server uses to write the variable. Also removes the temporary debug echo.

Closes blouin-labs/issues#81

🤖 Generated with [Claude Code](https://claude.com/claude-code)