### PR TITLE
chore(ci): standardize staged filenames and workflow env var names

### DIFF
--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -161,18 +161,18 @@ jobs:
           RUNNER_REG_APP_ID: ${{ vars.RUNNER_REG_APP_ID }}
           GH_DEPLOY_SSH_KEY: ${{ secrets.GH_DEPLOY_SSH_KEY }}
           GHIO_PULLER_PAT: ${{ secrets.GHIO_PULLER_PAT }}
-          HARBOR_BOOT_APP_KEY: ${{ secrets.HARBOR_BOOT_REPORTER_KEY }}
-          HARBOR_BOOT_APP_ID: ${{ vars.HARBOR_BOOT_REPORTER_APP_ID }}
+          HARBOR_BOOT_REPORTER_KEY: ${{ secrets.HARBOR_BOOT_REPORTER_KEY }}
+          HARBOR_BOOT_REPORTER_APP_ID: ${{ vars.HARBOR_BOOT_REPORTER_APP_ID }}
         run: |
           ssh harbor-srv 'umask 077; mkdir -p /var/lib/gh-deploy/harbor-deploy'
-          printf '%s' "$KRB5_SECRETS_B64"    | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/krb5-secrets.b64'
-          printf '%s' "$RUNNER_REG_APP_KEY"  | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/runner-reg-key.pem'
-          printf '%s' "$RUNNER_REG_APP_ID"   | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/runner-reg-app-id'
-          printf '%s' "$GH_DEPLOY_SSH_KEY"   | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/gh-deploy-key'
-          printf '%s' "$GHIO_PULLER_PAT"     | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/ghio-puller-pat'
-          printf '%s' "${{ github.run_id }}" | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/run-id'
-          printf '%s' "$HARBOR_BOOT_APP_KEY" | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/boot-app-key'
-          printf '%s' "$HARBOR_BOOT_APP_ID"  | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/boot-app-id'
+          printf '%s' "$KRB5_SECRETS_B64"          | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/krb5-secrets-b64'
+          printf '%s' "$RUNNER_REG_APP_KEY"         | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/runner-reg-app-key'
+          printf '%s' "$RUNNER_REG_APP_ID"          | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/runner-reg-app-id'
+          printf '%s' "$GH_DEPLOY_SSH_KEY"          | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/gh-deploy-ssh-key'
+          printf '%s' "$GHIO_PULLER_PAT"            | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/ghio-puller-pat'
+          printf '%s' "${{ github.run_id }}"        | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/deploy-run-id'
+          printf '%s' "$HARBOR_BOOT_REPORTER_KEY"   | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/harbor-boot-reporter-key'
+          printf '%s' "$HARBOR_BOOT_REPORTER_APP_ID" | ssh harbor-srv 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/harbor-boot-reporter-app-id'
 
       - name: Flash server
         run: |
@@ -192,17 +192,17 @@ jobs:
     steps:
       - name: Verify root partition
         env:
-          HARBOR_BOOT_APP_KEY: ${{ secrets.HARBOR_BOOT_REPORTER_KEY }}
-          HARBOR_BOOT_APP_ID: ${{ vars.HARBOR_BOOT_REPORTER_APP_ID }}
+          HARBOR_BOOT_REPORTER_KEY: ${{ secrets.HARBOR_BOOT_REPORTER_KEY }}
+          HARBOR_BOOT_REPORTER_APP_ID: ${{ vars.HARBOR_BOOT_REPORTER_APP_ID }}
         run: |
           EXPECTED="${{ needs.flash.outputs.target_label }}"
           RUN_ID="${{ github.run_id }}"
 
           KEY_FILE=$(mktemp)
-          printf '%s' "$HARBOR_BOOT_APP_KEY" > "$KEY_FILE"
+          printf '%s' "$HARBOR_BOOT_REPORTER_KEY" > "$KEY_FILE"
           NOW=$(date +%s)
           HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
-          PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' $((NOW - 60)) $((NOW + 600)) "$HARBOR_BOOT_APP_ID" \
+          PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' $((NOW - 60)) $((NOW + 600)) "$HARBOR_BOOT_REPORTER_APP_ID" \
                     | base64 -w0 | tr '+/' '-_' | tr -d '=')
           SIG=$(printf '%s.%s' "$HEADER" "$PAYLOAD" \
                 | openssl dgst -sha256 -sign "$KEY_FILE" \

--- a/profile/airootfs/usr/local/sbin/harbor-deploy.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy.sh
@@ -15,14 +15,14 @@ MOUNT_DIR=""
 SECRETS_DIR="/var/lib/gh-deploy/harbor-deploy"
 
 # Read secrets staged by the CI runner and delete them immediately.
-KRB5_SECRETS_B64=""   ; if [ -f "${SECRETS_DIR}/krb5-secrets.b64"   ]; then KRB5_SECRETS_B64=$(   cat "${SECRETS_DIR}/krb5-secrets.b64");   fi
-RUNNER_REG_APP_KEY="" ; if [ -f "${SECRETS_DIR}/runner-reg-key.pem" ]; then RUNNER_REG_APP_KEY=$( cat "${SECRETS_DIR}/runner-reg-key.pem"); fi
-RUNNER_REG_APP_ID=""  ; if [ -f "${SECRETS_DIR}/runner-reg-app-id"  ]; then RUNNER_REG_APP_ID=$(  cat "${SECRETS_DIR}/runner-reg-app-id");  fi
-GH_DEPLOY_SSH_KEY=""  ; if [ -f "${SECRETS_DIR}/gh-deploy-key"      ]; then GH_DEPLOY_SSH_KEY=$(  cat "${SECRETS_DIR}/gh-deploy-key");      fi
-GHIO_PULLER_PAT=""    ; if [ -f "${SECRETS_DIR}/ghio-puller-pat"    ]; then GHIO_PULLER_PAT=$(    cat "${SECRETS_DIR}/ghio-puller-pat");    fi
-DEPLOY_RUN_ID=""      ; if [ -f "${SECRETS_DIR}/run-id"             ]; then DEPLOY_RUN_ID=$(      cat "${SECRETS_DIR}/run-id");             fi
-HARBOR_BOOT_REPORTER_KEY=""; if [ -f "${SECRETS_DIR}/boot-app-key"       ]; then HARBOR_BOOT_REPORTER_KEY=$(cat "${SECRETS_DIR}/boot-app-key");       fi
-HARBOR_BOOT_REPORTER_APP_ID="" ; if [ -f "${SECRETS_DIR}/boot-app-id"        ]; then HARBOR_BOOT_REPORTER_APP_ID=$( cat "${SECRETS_DIR}/boot-app-id");        fi
+KRB5_SECRETS_B64=""   ; if [ -f "${SECRETS_DIR}/krb5-secrets-b64"            ]; then KRB5_SECRETS_B64=$(          cat "${SECRETS_DIR}/krb5-secrets-b64");            fi
+RUNNER_REG_APP_KEY="" ; if [ -f "${SECRETS_DIR}/runner-reg-app-key"          ]; then RUNNER_REG_APP_KEY=$(        cat "${SECRETS_DIR}/runner-reg-app-key");          fi
+RUNNER_REG_APP_ID=""  ; if [ -f "${SECRETS_DIR}/runner-reg-app-id"           ]; then RUNNER_REG_APP_ID=$(         cat "${SECRETS_DIR}/runner-reg-app-id");           fi
+GH_DEPLOY_SSH_KEY=""  ; if [ -f "${SECRETS_DIR}/gh-deploy-ssh-key"           ]; then GH_DEPLOY_SSH_KEY=$(         cat "${SECRETS_DIR}/gh-deploy-ssh-key");           fi
+GHIO_PULLER_PAT=""    ; if [ -f "${SECRETS_DIR}/ghio-puller-pat"             ]; then GHIO_PULLER_PAT=$(           cat "${SECRETS_DIR}/ghio-puller-pat");             fi
+DEPLOY_RUN_ID=""      ; if [ -f "${SECRETS_DIR}/deploy-run-id"               ]; then DEPLOY_RUN_ID=$(             cat "${SECRETS_DIR}/deploy-run-id");               fi
+HARBOR_BOOT_REPORTER_KEY=""    ; if [ -f "${SECRETS_DIR}/harbor-boot-reporter-key"    ]; then HARBOR_BOOT_REPORTER_KEY=$(   cat "${SECRETS_DIR}/harbor-boot-reporter-key");    fi
+HARBOR_BOOT_REPORTER_APP_ID="" ; if [ -f "${SECRETS_DIR}/harbor-boot-reporter-app-id" ]; then HARBOR_BOOT_REPORTER_APP_ID=$(cat "${SECRETS_DIR}/harbor-boot-reporter-app-id"); fi
 rm -rf "$SECRETS_DIR"
 
 cleanup() {


### PR DESCRIPTION
## Summary

- Renames all 6 staged filenames in `/var/lib/gh-deploy/harbor-deploy/` to match the canonical `UPPER_SNAKE_CASE` secret/var name (e.g. `runner-reg-key.pem` → `runner-reg-app-key`, `boot-app-key` → `harbor-boot-reporter-key`)
- Renames `HARBOR_BOOT_APP_KEY`/`HARBOR_BOOT_APP_ID` workflow env vars to `HARBOR_BOOT_REPORTER_KEY`/`HARBOR_BOOT_REPORTER_APP_ID` in both the `flash` and `verify` steps
- `harbor-deploy.sh` read paths updated to match the new filenames

No logic changes. No GitHub secret or variable renames needed — those are already canonical.

## Test plan

- [ ] Trigger promotion.yml (`deploy` action) and confirm secrets are staged and read without errors
- [ ] Verify `HARBOR_BOOT_LAST` is updated in repo vars after deploy

Closes blouin-labs/issues#85

🤖 Generated with [Claude Code](https://claude.com/claude-code)