### PR TITLE
feat(harbor_srv): use pacoloco proxy as primary pacman mirror

### DIFF
--- a/profile/pacman.conf
+++ b/profile/pacman.conf
@@ -84,7 +84,9 @@ LocalFileSigLevel = Optional
 #
 
 [core]
+Server = http://192.168.1.5:9129/repo/archlinux/repos/@ARCH_SNAPSHOT@/$repo/os/$arch
 Server = https://archive.archlinux.org/repos/@ARCH_SNAPSHOT@/$repo/os/$arch
 
 [extra]
+Server = http://192.168.1.5:9129/repo/archlinux/repos/@ARCH_SNAPSHOT@/$repo/os/$arch
 Server = https://archive.archlinux.org/repos/@ARCH_SNAPSHOT@/$repo/os/$arch


### PR DESCRIPTION
## Summary

- Adds pacoloco proxy (`http://192.168.1.5:9129/repo/archlinux/...`) as the first `Server` in `[core]` and `[extra]`
- Keeps `archive.archlinux.org` as the second `Server` — pacman falls back automatically on connection failure

## Notes

Depends on mooring_field pacoloco stack being deployed first. The fallback ensures builds succeed on cloud runners (which can't reach 192.168.1.5) and during harbor_srv reboots.

## Test plan

- [ ] Ensure mooring_field pacoloco stack is deployed and running
- [ ] Trigger a build — confirm packages download via proxy in build log
- [ ] Trigger a second build (same `ARCH_SNAPSHOT`) — faster due to cache hits

Refs blouin-labs/issues#90

🤖 Generated with [Claude Code](https://claude.com/claude-code)