### PR TITLE
fix(ci): pin SSH host key to prevent verification failure after OS flash

### DIFF
--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -69,18 +69,19 @@ jobs:
     runs-on: [self-hosted, harbor-srv-docker]
     container: ubuntu:latest
     env:
-      # TODO(blouin-labs/issues#93): replace StrictHostKeyChecking=no with pinned host key
-      SSH_OPTS: -i /root/.ssh/gh-deploy-ssh-key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+      SSH_OPTS: -i /root/.ssh/gh-deploy-ssh-key -o StrictHostKeyChecking=yes
     if: ${{ always() && (inputs.action == 'promote-and-deploy' || inputs.action == 'deploy') }}
     steps:
       - name: Set up environment
         env:
           GH_DEPLOY_SSH_KEY: ${{ secrets.GH_DEPLOY_SSH_KEY }}
+          HARBOR_SRV_KNOWN_HOSTS: ${{ secrets.HARBOR_SRV_KNOWN_HOSTS }}
         run: |
           apt-get update -qq && apt-get install -y -qq curl jq unzip openssh-client
           install -d -m700 /root/.ssh
           printf '%s\n' "$GH_DEPLOY_SSH_KEY" > /root/.ssh/gh-deploy-ssh-key
           chmod 600 /root/.ssh/gh-deploy-ssh-key
+          printf '%s\n' "$HARBOR_SRV_KNOWN_HOSTS" >> /root/.ssh/known_hosts
 
       - name: Confirm
         run: |
@@ -140,8 +141,7 @@ jobs:
     runs-on: [self-hosted, harbor-srv-docker]
     container: ubuntu:latest
     env:
-      # TODO(blouin-labs/issues#93): replace StrictHostKeyChecking=no with pinned host key
-      SSH_OPTS: -i /root/.ssh/gh-deploy-ssh-key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+      SSH_OPTS: -i /root/.ssh/gh-deploy-ssh-key -o StrictHostKeyChecking=yes
     if: ${{ always() && needs.download.result == 'success' }}
     outputs:
       target_label: ${{ steps.target.outputs.target_label }}
@@ -149,11 +149,13 @@ jobs:
       - name: Set up environment
         env:
           GH_DEPLOY_SSH_KEY: ${{ secrets.GH_DEPLOY_SSH_KEY }}
+          HARBOR_SRV_KNOWN_HOSTS: ${{ secrets.HARBOR_SRV_KNOWN_HOSTS }}
         run: |
           apt-get update -qq && apt-get install -y -qq curl jq openssh-client
           install -d -m700 /root/.ssh
           printf '%s\n' "$GH_DEPLOY_SSH_KEY" > /root/.ssh/gh-deploy-ssh-key
           chmod 600 /root/.ssh/gh-deploy-ssh-key
+          printf '%s\n' "$HARBOR_SRV_KNOWN_HOSTS" >> /root/.ssh/known_hosts
 
       - name: Determine target partition
         id: target
@@ -193,6 +195,7 @@ jobs:
           GHIO_PULLER_PAT: ${{ secrets.GHIO_PULLER_PAT }}
           HARBOR_BOOT_REPORTER_KEY: ${{ secrets.HARBOR_BOOT_REPORTER_KEY }}
           HARBOR_BOOT_REPORTER_APP_ID: ${{ vars.HARBOR_BOOT_REPORTER_APP_ID }}
+          HARBOR_SRV_HOST_KEY: ${{ secrets.HARBOR_SRV_HOST_KEY }}
         run: |
           # shellcheck disable=SC2086
           ssh $SSH_OPTS gh-deploy@192.168.1.5 'umask 077; mkdir -p /var/lib/gh-deploy/harbor-deploy'
@@ -212,6 +215,8 @@ jobs:
           printf '%s' "$HARBOR_BOOT_REPORTER_KEY"   | ssh $SSH_OPTS gh-deploy@192.168.1.5 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/harbor-boot-reporter-key'
           # shellcheck disable=SC2086
           printf '%s' "$HARBOR_BOOT_REPORTER_APP_ID" | ssh $SSH_OPTS gh-deploy@192.168.1.5 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/harbor-boot-reporter-app-id'
+          # shellcheck disable=SC2086
+          printf '%s' "$HARBOR_SRV_HOST_KEY"        | ssh $SSH_OPTS gh-deploy@192.168.1.5 'umask 077; cat > /var/lib/gh-deploy/harbor-deploy/harbor-srv-host-key'
 
       - name: Flash server
         run: |

--- a/profile/airootfs/usr/local/sbin/harbor-deploy.sh
+++ b/profile/airootfs/usr/local/sbin/harbor-deploy.sh
@@ -23,6 +23,7 @@ GHIO_PULLER_PAT=""    ; if [ -f "${SECRETS_DIR}/ghio-puller-pat"             ]; 
 DEPLOY_RUN_ID=""      ; if [ -f "${SECRETS_DIR}/deploy-run-id"               ]; then DEPLOY_RUN_ID=$(             cat "${SECRETS_DIR}/deploy-run-id");               fi
 HARBOR_BOOT_REPORTER_KEY=""    ; if [ -f "${SECRETS_DIR}/harbor-boot-reporter-key"    ]; then HARBOR_BOOT_REPORTER_KEY=$(   cat "${SECRETS_DIR}/harbor-boot-reporter-key");    fi
 HARBOR_BOOT_REPORTER_APP_ID="" ; if [ -f "${SECRETS_DIR}/harbor-boot-reporter-app-id" ]; then HARBOR_BOOT_REPORTER_APP_ID=$(cat "${SECRETS_DIR}/harbor-boot-reporter-app-id"); fi
+HARBOR_SRV_HOST_KEY=""         ; if [ -f "${SECRETS_DIR}/harbor-srv-host-key"          ]; then HARBOR_SRV_HOST_KEY=$(        cat "${SECRETS_DIR}/harbor-srv-host-key");          fi
 rm -rf "$SECRETS_DIR"
 
 cleanup() {
@@ -183,6 +184,22 @@ if [ -n "${GHIO_PULLER_PAT:-}" ]; then
     echo ":: ghio-puller PAT injected."
 else
     echo "WARNING: GHIO_PULLER_PAT not set — ghcr.io docker login will fail on boot" >&2
+fi
+
+# --- Inject SSH host key (ensures host key is consistent across OS flashes) ---
+if [ -n "${HARBOR_SRV_HOST_KEY:-}" ]; then
+    echo ":: Injecting SSH host key..."
+    printf '%s\n' "$HARBOR_SRV_HOST_KEY" > "${MOUNT_DIR}/etc/ssh/ssh_host_ed25519_key"
+    chmod 600 "${MOUNT_DIR}/etc/ssh/ssh_host_ed25519_key"
+    chown 0:0 "${MOUNT_DIR}/etc/ssh/ssh_host_ed25519_key"
+    ssh-keygen -y -f "${MOUNT_DIR}/etc/ssh/ssh_host_ed25519_key" \
+        > "${MOUNT_DIR}/etc/ssh/ssh_host_ed25519_key.pub"
+    chmod 644 "${MOUNT_DIR}/etc/ssh/ssh_host_ed25519_key.pub"
+    chown 0:0 "${MOUNT_DIR}/etc/ssh/ssh_host_ed25519_key.pub"
+    unset HARBOR_SRV_HOST_KEY
+    echo ":: SSH host key injected."
+else
+    echo "WARNING: HARBOR_SRV_HOST_KEY not set — host key will be regenerated on boot" >&2
 fi
 
 # --- Inject post-boot verification context and harbor-boot-reporter App credentials ---


### PR DESCRIPTION
## Summary

- Injects the server's ed25519 host private key (`HARBOR_SRV_HOST_KEY`) into `/etc/ssh/` on the new root during deploy so the host presents the same key after every OS flash
- CI jobs (`download` and `flash`) now write `HARBOR_SRV_KNOWN_HOSTS` into `~/.ssh/known_hosts` and use `StrictHostKeyChecking=yes`
- Removes the temporary `StrictHostKeyChecking=no` workaround and its TODO comments

## Secrets required (already set)

- `HARBOR_SRV_HOST_KEY` — server's current ed25519 host private key
- `HARBOR_SRV_KNOWN_HOSTS` — `known_hosts` line (`192.168.1.5 ssh-ed25519 ...`)

## Test plan

- [ ] Trigger Promotion → `deploy` — confirm `download` and `flash` jobs succeed with no SSH host key errors
- [ ] After server reboots, trigger another deploy — confirm key still matches (injected key persists across flashes)

Closes blouin-labs/issues#93

🤖 Generated with [Claude Code](https://claude.ai/claude-code)