### PR TITLE
feat(nfs): use machine credential for all UIDs on Kerberos NFS mount

### DIFF
--- a/profile/airootfs/etc/systemd/system/rpc-gssd.service.d/no-user-creds.conf
+++ b/profile/airootfs/etc/systemd/system/rpc-gssd.service.d/no-user-creds.conf
@@ -1,0 +1,6 @@
+[Service]
+# Use machine credentials for all UIDs, not per-user credential caches.
+# Without this, non-root processes (e.g. compose-deploy) cannot establish
+# a GSS context for sec=krb5i NFS access.
+ExecStart=
+ExecStart=/usr/sbin/rpc.gssd -n


### PR DESCRIPTION
## Summary

Adds a rpc-gssd drop-in that passes the `-n` flag, telling rpc-gssd to use the machine credential from `/etc/krb5.keytab` for all UIDs rather than looking for per-user credential caches.

Without this, non-root users (e.g. `compose-deploy`, UID 966) cannot establish a GSS context for the `sec=krb5i` NFS mount and get Permission Denied on any file access.

Tested live: `compose-deploy` can create directories and write files under `/mnt/synology/harbor_srv/docker/`, and is correctly denied writes outside that directory.

Refs blouin-labs/issues#43

🤖 Generated with [Claude Code](https://claude.com/claude-code)