### PR TITLE
fix(nfs): kinit from keytab after gssd starts so mount can auth

### DIFF
--- a/profile/airootfs/etc/systemd/system/rpc-gssd.service.d/keytab-init.conf
+++ b/profile/airootfs/etc/systemd/system/rpc-gssd.service.d/keytab-init.conf
@@ -1,0 +1,5 @@
+[Service]
+# Obtain a TGT from the KDC using the machine keytab after gssd starts.
+# The NFS mount operation (sec=krb5i) requires root's credential cache
+# (/tmp/krb5cc_0) even when rpc.gssd -n is used for per-UID file access.
+ExecStartPost=/usr/bin/kinit -k nfs/harbor-srv@HARBOR.LOCAL


### PR DESCRIPTION
## Summary

`rpc.gssd -n` populates `/tmp/krb5ccmachine_HARBOR.LOCAL` for per-UID file access but the NFS mount operation itself requires a TGT in root's default ccache (`/tmp/krb5cc_0`). Without it, `mount.nfs` gets `access denied by server` even though gssd is running and the keytab is valid.

Add `keytab-init.conf` drop-in under `rpc-gssd.service.d` with `ExecStartPost=/usr/bin/kinit -k nfs/harbor-srv@HARBOR.LOCAL`. Since the mount unit is `After=rpc-gssd.service`, the ccache is guaranteed to be present before the mount is attempted.

Tested live: mount succeeds without a manual `kinit` after this change.

Closes blouin-labs/issues#107
Refs blouin-labs/issues#43

🤖 Generated with [Claude Code](https://claude.com/claude-code)