### PR TITLE
fix(ci): decouple docker from NFS; restore runner restart policy

### DIFF
--- a/profile/airootfs/etc/harbor-runner/compose.yaml
+++ b/profile/airootfs/etc/harbor-runner/compose.yaml
@@ -7,6 +7,7 @@ services:
   runner:
     image: ghcr.io/blouin-labs/dind-runner:latest
     container_name: harbor-runner
+    restart: unless-stopped
     privileged: true
     # Explicit DNS: the host resolv.conf is empty (systemd-resolved stub), so Docker's
     # embedded DNS for custom bridge networks has no upstream to forward to.

--- a/profile/airootfs/etc/systemd/system/docker.service.d/nfs-dependency.conf
+++ b/profile/airootfs/etc/systemd/system/docker.service.d/nfs-dependency.conf
@@ -1,4 +1,0 @@
-[Unit]
-After=mnt-synology-harbor_srv-retry.service
-Requires=mnt-synology-harbor_srv-retry.service
-BindsTo=mnt-synology-harbor_srv.mount

--- a/profile/airootfs/etc/systemd/system/harbor-compose.service
+++ b/profile/airootfs/etc/systemd/system/harbor-compose.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Start Docker Compose stacks from NFS share
-After=docker.service
-Requires=docker.service
+After=docker.service mnt-synology-harbor_srv-retry.service
+Requires=docker.service mnt-synology-harbor_srv-retry.service
+BindsTo=mnt-synology-harbor_srv.mount
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Summary

- Remove `docker.service.d/nfs-dependency.conf` — docker itself doesn't need the NFS share; binding it to the Synology mount blocked docker (and the runner) on every boot where `rpc.gssd` is slow to initialise
- Move the NFS dependency to `harbor-compose.service`, which is the unit that actually reads compose stacks from `/mnt/synology/harbor_srv`
- Restore `restart: unless-stopped` in harbor-runner `compose.yaml` — without it, when `run.sh` exits 0 (clean shutdown, e.g. runner deregistered by GitHub), `docker compose up` exits 0, `Restart=on-failure` doesn't fire, and the runner stays dead while the systemd service appears `active (running)`

## New boot dependency graph

```
network-online → krb5-kdc → rpc-gssd → mnt-synology → retry-service
                                                              ↓
docker (no NFS dep) → ghio-puller-login → harbor-runner   harbor-compose
```

Docker and the runner start independently of NFS. `harbor-compose` still waits for NFS.

Refs blouin-labs/issues#109

## Test plan

- [ ] Deploy to staging and reboot server
- [ ] Confirm `harbor-runner.service` is `active (running)` and container is up within ~60s of boot
- [ ] Confirm `harbor-srv-docker` runner shows online in GitHub → blouin-labs → Settings → Runners
- [ ] Trigger a Checks run on a PR and confirm `harbor-srv-docker` picks it up
- [ ] Confirm `harbor-compose.service` starts correctly once NFS mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)