### PR TITLE
fix(image): add rsync to packages.x86_64

### DIFF
--- a/profile/packages.x86_64
+++ b/profile/packages.x86_64
@@ -5,6 +5,7 @@ linux-firmware
 mkinitcpio
 intel-ucode
 openssh
+rsync
 pv
 
 # Harbor Srv


### PR DESCRIPTION
## Summary

- Adds `rsync` to `profile/packages.x86_64` so it is baked into the harbor_srv image
- Fixes the `protocol version mismatch` error in mooring_field deployments caused by rsync not being found on the remote

## Test plan

- [x] Installed rsync on live server and verified `rsync --version` (3.4.1)
- [x] Ran end-to-end `rsync -e "ssh ..."` transfer from runner to server — succeeded cleanly

Closes blouin-labs/issues#100

🤖 Generated with [Claude Code](https://claude.com/claude-code)