### PR TITLE
fix(image): fix compose-deploy for mooring_field deploys

### DIFF
--- a/profile/airootfs/etc/passwd
+++ b/profile/airootfs/etc/passwd
@@ -18,4 +18,4 @@ alpm:x:969:969:Arch Linux Package Management:/:/usr/bin/nologin
 rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/usr/bin/nologin
 rpcuser:x:34:34:RPC Service User:/var/lib/nfs:/usr/bin/nologin
 gh-deploy:x:967:967:GitHub Deploy Runner:/var/lib/gh-deploy:/bin/bash
-compose-deploy:x:966:966:Compose Deploy Runner:/var/lib/compose-deploy:/usr/bin/nologin
+compose-deploy:x:966:966:Compose Deploy Runner:/var/lib/compose-deploy:/bin/sh

--- a/profile/airootfs/etc/sudoers.d/compose-deploy
+++ b/profile/airootfs/etc/sudoers.d/compose-deploy
@@ -1,0 +1,1 @@
+compose-deploy ALL=(root) NOPASSWD: /usr/bin/rsync --server *


### PR DESCRIPTION
## Summary

- Changes `compose-deploy` shell from `/usr/bin/nologin` → `/bin/sh` so SSH can execute commands (rsync --server, bash -s)
- Adds `sudoers.d/compose-deploy` scoped to `rsync --server *` — lets rsync run as root, which holds the machine Kerberos credential needed for `sec=krb5i` NFS writes

## Test plan

- [x] Applied both changes to live server
- [x] Confirmed `compose-deploy` can run `sudo rsync --server` without password (`sudo -n` test)
- [x] Confirmed root can write to `/mnt/synology/harbor_srv/docker/` (NFS machine credential works)
- [ ] End-to-end mooring_field deploy after this image is promoted (covered by companion PR in mooring_field)

Closes blouin-labs/issues#101

🤖 Generated with [Claude Code](https://claude.com/claude-code)