### PR TITLE
fix(image): allow compose-deploy to run harbor-compose-update.sh via sudo

### DIFF
--- a/profile/airootfs/etc/sudoers.d/compose-deploy
+++ b/profile/airootfs/etc/sudoers.d/compose-deploy
@@ -1,1 +1,2 @@
 compose-deploy ALL=(root) NOPASSWD: /usr/bin/rsync --server *
+compose-deploy ALL=(root) NOPASSWD: /usr/local/bin/harbor-compose-update.sh


### PR DESCRIPTION
## Summary

- Adds a scoped `NOPASSWD` sudoers rule for `compose-deploy` to run `/usr/local/bin/harbor-compose-update.sh` as root

## Root cause

`compose-deploy` (uid 966) has no Kerberos credential for the NFS mount (`sec=krb5i`). The mooring_field deploy job's "Start/update stacks" step ran `find /mnt/synology/harbor_srv/docker` directly as compose-deploy — permission denied. `harbor-compose-update.sh` already exists in the image and does the same pull+up loop as root (machine credential).

## Test plan

- [x] Applied sudoers rule to live server
- [x] Ran `sudo -u compose-deploy sudo harbor-compose-update.sh` — all 3 stacks updated successfully
- [ ] End-to-end deploy after this image is promoted (covered by companion PR in mooring_field)

Closes blouin-labs/issues#101

🤖 Generated with [Claude Code](https://claude.com/claude-code)