### PR TITLE
fix(image): pre-create bind-mount dirs before docker compose up

### DIFF
--- a/profile/airootfs/usr/local/bin/harbor-compose-update.sh
+++ b/profile/airootfs/usr/local/bin/harbor-compose-update.sh
@@ -20,6 +20,15 @@ update_stack() {
         return
     fi
 
+    # Pre-create bind-mount source directories so Docker doesn't try to chown
+    # them on startup — chown fails on NFS (sec=krb5i squashes all UIDs to nobody).
+    docker compose -f "${compose_file}" config 2>/dev/null \
+        | grep -A1 'type: bind' \
+        | awk '/source:/{print $2}' \
+        | while IFS= read -r src; do
+            mkdir -p "${src}" 2>/dev/null || true
+          done
+
     echo ":: [${project}] Pulling latest images..."
     if ! docker compose -f "${compose_file}" --project-name "${project}" pull; then
         echo ":: [${project}] WARNING: pull failed, continuing with existing images" >&2


### PR DESCRIPTION
## Summary

- In `harbor-compose-update.sh`, parses each stack's compose config for bind-mount source paths and `mkdir -p`s them before pulling/starting
- Prevents Docker from trying to `chown` newly created directories on the NFS mount, which fails with `EINVAL` (`sec=krb5i` squashes all UIDs to `nobody`)

## Root cause

Docker creates missing host-side directories for bind mounts on startup, then immediately calls `chown` to set ownership. The NFS mount rejects `chown` with `invalid argument`. If the directory already exists, Docker skips the `chown`.

## Test plan

- [x] Verified `grep -A1 'type: bind' | awk '/source:/{print $2}'` correctly extracts both bind-mount sources from pacoloco's compose config on live server
- [x] Pre-created `/mnt/synology/harbor_srv/docker/pacoloco/data` manually to unblock current deploy
- [ ] Next mooring_field deploy should start pacoloco cleanly without the chown error

Closes blouin-labs/issues#101

🤖 Generated with [Claude Code](https://claude.com/claude-code)