### PR TITLE
fix(airootfs): symlink resolv.conf to systemd-resolved stub

### DIFF
--- a/profile/airootfs/etc/resolv.conf
+++ b/profile/airootfs/etc/resolv.conf
@@ -1,0 +1,1 @@
+/run/systemd/resolve/stub-resolv.conf


### PR DESCRIPTION
## Summary

- Adds `profile/airootfs/etc/resolv.conf` as a symlink to `/run/systemd/resolve/stub-resolv.conf`, matching the [archlinux/archiso releng convention](https://github.com/archlinux/archiso/blob/master/configs/releng/airootfs/etc/resolv.conf)
- Without this, `/etc/resolv.conf` is a static file with only comments and no `nameserver` entries, leaving Docker's embedded DNS resolver (`127.0.0.11`) with no upstream — all container DNS lookups fail with "server misbehaving"
- Docker detects the loopback stub address (`127.0.0.53`) and automatically substitutes `8.8.8.8`, restoring DNS for all containers

## Background

Diagnosed while investigating why pacoloco's cache was empty. Container logs showed DNS failures on every upstream request. The live server has a temporary hotfix (`/etc/docker/daemon.json` with explicit DNS servers) applied manually — this PR replaces that with the correct permanent fix baked into the image.

Refs blouin-labs/issues#110

## Test plan

- [ ] Build completes successfully
- [ ] After flash, verify `readlink /etc/resolv.conf` returns `/run/systemd/resolve/stub-resolv.conf`
- [ ] Verify Docker containers can resolve external hostnames: `docker run --rm alpine nslookup archive.archlinux.org`
- [ ] Trigger a harbor_srv build and confirm pacoloco cache fills (`ls /mnt/synology/harbor_srv/docker/pacoloco/data/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)