### PR TITLE
fix(harbor_srv): add systemd timer to renew Kerberos TGT every 12h

### DIFF
--- a/profile/airootfs/etc/systemd/system/krb5-ticket-renew.service
+++ b/profile/airootfs/etc/systemd/system/krb5-ticket-renew.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Renew Kerberos TGT for NFS mount
+After=krb5-kdc.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/kinit -k nfs/harbor-srv@HARBOR.LOCAL

--- a/profile/airootfs/etc/systemd/system/krb5-ticket-renew.timer
+++ b/profile/airootfs/etc/systemd/system/krb5-ticket-renew.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Renew Kerberos TGT every 12 hours
+
+[Timer]
+OnBootSec=12h
+OnUnitActiveSec=12h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/profile/airootfs/etc/systemd/system/timers.target.wants/krb5-ticket-renew.timer
+++ b/profile/airootfs/etc/systemd/system/timers.target.wants/krb5-ticket-renew.timer
@@ -1,0 +1,1 @@
+../krb5-ticket-renew.timer


### PR DESCRIPTION
## Summary

- Adds `krb5-ticket-renew.service` — oneshot `kinit -k nfs/harbor-srv@HARBOR.LOCAL` triggered by the timer
- Adds `krb5-ticket-renew.timer` — fires every 12 hours (`OnBootSec=12h`, `OnUnitActiveSec=12h`, `Persistent=true`)
- Adds `timers.target.wants/krb5-ticket-renew.timer` symlink to enable the timer at boot

Uses `kinit -k` (keytab re-acquisition) rather than `kinit -R` (renewal) because it is unconditional — it works even if the current ticket has already expired. Boot-time kinit is already handled by `rpc-gssd.service.d/keytab-init.conf`; this timer only covers in-uptime renewal.

Closes blouin-labs/issues#111

## Test plan

- [ ] After deploy: `ssh root@192.168.1.5 'systemctl status krb5-ticket-renew.timer'` — should show active/waiting with next trigger ~12h from boot
- [ ] `systemctl list-timers krb5-ticket-renew.timer` — confirms schedule
- [ ] `journalctl -u krb5-ticket-renew.service` — shows last run result after timer fires
- [ ] `klist` on the server — confirms a valid TGT is present with fresh expiry after timer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)