### PR TITLE
feat(security): periodic arch-audit of deployed build

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,8 +11,13 @@ permissions:
   actions: read
 
 jobs:
+  select-runner:
+    uses: ./.github/workflows/select-runner.yml
+    secrets: inherit
+
   arch-audit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.select-runner.outputs.runner) }}
+    needs: select-runner
     container:
       # Intentionally unpinned: always use the latest advisory data and arch-audit version.
       # Unlike the build, reproducibility is not a goal here — freshness is.

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,87 @@
+---
+name: Security Audit
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'  # Weekly, Monday 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  arch-audit:
+    runs-on: ubuntu-latest
+    container:
+      # Intentionally unpinned: always use the latest advisory data and arch-audit version.
+      # Unlike the build, reproducibility is not a goal here — freshness is.
+      image: archlinux/archlinux:latest
+    steps:
+      - name: Install arch-audit
+        run: pacman -Sy --noconfirm arch-audit unzip
+
+      - name: Resolve main HEAD SHA
+        id: sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHORT=$(curl -sf \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/git/refs/heads/main" \
+            | jq -r '.object.sha[:7]')
+          echo "short=${SHORT}" >> "$GITHUB_OUTPUT"
+          echo "Auditing build: ${SHORT}"
+
+      - name: Download pacman DB artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARTIFACT_NAME="harbor_srv-pacman-db-${{ steps.sha.outputs.short }}"
+          ARTIFACT_URL=$(curl -sf \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=1" \
+            | jq -r '.artifacts[0].archive_download_url // empty')
+          if [ -z "$ARTIFACT_URL" ]; then
+            echo "ERROR: artifact ${ARTIFACT_NAME} not found (expired or never built)" >&2
+            exit 1
+          fi
+          curl -sL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -o /tmp/pacman-db-artifact.zip \
+            "$ARTIFACT_URL"
+          unzip -q /tmp/pacman-db-artifact.zip -d /tmp/
+
+      - name: Prepare pacman DB
+        run: |
+          mkdir -p /tmp/audit-db
+          tar -xzf /tmp/pacman-db-local.tar.gz -C /tmp/audit-db/
+
+      - name: Run arch-audit
+        run: |
+          set +e
+          RESULT=$(arch-audit --dbpath /tmp/audit-db 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          echo "$RESULT"
+
+          {
+            echo "## arch-audit — harbor-srv ($(date -u '+%Y-%m-%d'))"
+            echo ""
+            echo "**Build:** \`${{ steps.sha.outputs.short }}\`"
+            echo ""
+            if [ "$EXIT_CODE" -eq 0 ]; then
+              echo "No known vulnerabilities found."
+            else
+              echo "### Vulnerabilities found"
+              echo ""
+              echo "\`\`\`"
+              echo "$RESULT"
+              echo "\`\`\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$EXIT_CODE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,15 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: harbor_srv-root-${{ steps.sha.outputs.short }}
-          path: output/
+          path: output/harbor_srv-root.img.zst*
           retention-days: 30
+
+      - name: Upload pacman DB artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: harbor_srv-pacman-db-${{ steps.sha.outputs.short }}
+          path: output/pacman-db-local.tar.gz
+          retention-days: 90
 
       - name: Write build summary
         env:

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -151,6 +151,10 @@ arch-chroot "${WORK_DIR}/mnt" systemctl enable \
 # Generate initramfs (now with our custom preset and hooks config)
 arch-chroot "${WORK_DIR}/mnt" mkinitcpio -P
 
+# --- Export pacman local DB for security auditing ---
+echo ":: Exporting pacman DB..."
+tar -C "${WORK_DIR}/mnt/var/lib/pacman" -czf "${OUTPUT_DIR}/pacman-db-local.tar.gz" local/
+
 # --- Finalize ---
 echo ":: Syncing and unmounting..."
 sync


### PR DESCRIPTION
## Summary

- Exports the pacman local DB as a small secondary artifact (~200 KB, 90-day retention) at build time, avoiding the need to download the full image for auditing
- New weekly scheduled workflow (`audit.yml`) runs `arch-audit` against the deployed build's package versions in an Arch Linux container; fails if CVEs are found
- Also scopes the root image artifact upload path so the new DB file isn't bundled into it

## Test plan

- [ ] Push to `staging` on `profile/**` or `scripts/**` path → confirm both `harbor_srv-root-{sha}` and `harbor_srv-pacman-db-{sha}` artifacts appear in the build run
- [ ] Trigger `Security Audit` workflow manually via `workflow_dispatch` → confirm it resolves main HEAD, downloads the DB artifact, runs arch-audit, and writes the step summary
- [ ] Confirm workflow fails (non-zero exit) when vulnerabilities are present, passes when clean

Closes blouin-labs/issues#117
Refs blouin-labs/issues#8

🤖 Generated with [Claude Code](https://claude.com/claude-code)