### PR TITLE
fix(ci): install jq in audit container

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,7 +24,7 @@ jobs:
       image: archlinux/archlinux:latest
     steps:
       - name: Install arch-audit
-        run: pacman -Sy --noconfirm arch-audit unzip
+        run: pacman -Sy --noconfirm arch-audit jq unzip
 
       - name: Resolve main HEAD SHA
         id: sha


### PR DESCRIPTION
## Summary

- The base `archlinux/archlinux` image doesn't include `jq`; adds it to the `pacman -Sy` install step alongside `arch-audit` and `unzip`

## Test plan

- [ ] Trigger `Security Audit` manually via `workflow_dispatch` — confirm the SHA resolution step no longer fails with `jq: command not found`

Refs blouin-labs/issues#117

🤖 Generated with [Claude Code](https://claude.com/claude-code)