### PR TITLE
feat(ci): add --color and --show-cve to arch-audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run arch-audit
         run: |
           set +e
-          RESULT=$(arch-audit --dbpath /tmp/audit-db 2>&1)
+          RESULT=$(arch-audit --dbpath /tmp/audit-db --color --show-cve 2>&1)
           EXIT_CODE=$?
           set -e
 


### PR DESCRIPTION
## Summary

- Adds `--color` and `--show-cve` flags to the `arch-audit` invocation so CVE identifiers are included in the output and step summary

Refs blouin-labs/issues#117

🤖 Generated with [Claude Code](https://claude.com/claude-code)