### PR TITLE
fix(ci): pass explicit value to arch-audit --color

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run arch-audit
         run: |
           set +e
-          RESULT=$(arch-audit --dbpath /tmp/audit-db --color --show-cve 2>&1)
+          RESULT=$(arch-audit --dbpath /tmp/audit-db --color auto --show-cve 2>&1)
           EXIT_CODE=$?
           set -e
 


### PR DESCRIPTION
## Summary

- `--color` requires an explicit argument despite the manpage implying a default; pass `auto` explicitly

Refs blouin-labs/issues#117

🤖 Generated with [Claude Code](https://claude.com/claude-code)