### PR TITLE
fix(ci): reliability fixes for arch-audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,7 +24,9 @@ jobs:
       image: archlinux/archlinux:latest
     steps:
       - name: Install arch-audit
-        run: pacman -Sy --noconfirm arch-audit jq unzip
+        run: |
+          pacman -Sy --noconfirm archlinux-keyring
+          pacman -Sy --noconfirm arch-audit jq unzip
 
       - name: Resolve main HEAD SHA
         id: sha
@@ -67,26 +69,27 @@ jobs:
       - name: Run arch-audit
         run: |
           set +e
-          RESULT=$(arch-audit --dbpath /tmp/audit-db --color auto --show-cve 2>&1)
+          RESULT=$(arch-audit --dbpath /tmp/audit-db --show-cve)
           EXIT_CODE=$?
           set -e
-
-          echo "$RESULT"
 
           {
             echo "## arch-audit — harbor-srv ($(date -u '+%Y-%m-%d'))"
             echo ""
             echo "**Build:** \`${{ steps.sha.outputs.short }}\`"
             echo ""
-            if [ "$EXIT_CODE" -eq 0 ]; then
-              echo "No known vulnerabilities found."
-            else
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "$RESULT" ] || [ "$EXIT_CODE" -ne 0 ]; then
+            echo "$RESULT"
+            {
               echo "### Vulnerabilities found"
               echo ""
               echo "\`\`\`"
               echo "$RESULT"
               echo "\`\`\`"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          exit "$EXIT_CODE"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          else
+            echo "No known vulnerabilities found." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

- **Keyring refresh**: adds `pacman -Sy --noconfirm archlinux-keyring` before installing packages — the container image may be days old and signature verification will fail without a current keyring (mirrors the `build.yml` pattern)
- **Drop `2>&1`**: stderr (errors, warnings) no longer contaminates the captured output used in the step summary
- **Drop `--color auto`**: output is captured via `$()` so it's never a TTY; `auto` always resolved to no color and the flag did nothing
- **Fix summary bug**: arch-audit exits 0 even when vulnerabilities are present, so the previous `if [ "$EXIT_CODE" -eq 0 ]` branch always showed "No known vulnerabilities found"; now keys off non-empty `$RESULT` (with non-zero exit as fallback) instead

Refs blouin-labs/issues#117

🤖 Generated with [Claude Code](https://claude.com/claude-code)