### PR TITLE
feat(ci): structured vulnerability table in audit summary

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,7 +24,9 @@ jobs:
       image: archlinux/archlinux:latest
     steps:
       - name: Install arch-audit
-        run: pacman -Sy --noconfirm arch-audit jq unzip
+        run: |
+          pacman -Sy --noconfirm archlinux-keyring
+          pacman -Sy --noconfirm arch-audit jq unzip
 
       - name: Resolve main HEAD SHA
         id: sha
@@ -67,26 +69,36 @@ jobs:
       - name: Run arch-audit
         run: |
           set +e
-          RESULT=$(arch-audit --dbpath /tmp/audit-db --color auto --show-cve 2>&1)
+          RESULT=$(arch-audit --dbpath /tmp/audit-db --show-cve --format "%n|%c|%s|%v")
           EXIT_CODE=$?
           set -e
-
-          echo "$RESULT"
 
           {
             echo "## arch-audit — harbor-srv ($(date -u '+%Y-%m-%d'))"
             echo ""
             echo "**Build:** \`${{ steps.sha.outputs.short }}\`"
             echo ""
-            if [ "$EXIT_CODE" -eq 0 ]; then
-              echo "No known vulnerabilities found."
-            else
-              echo "### Vulnerabilities found"
-              echo ""
-              echo "\`\`\`"
-              echo "$RESULT"
-              echo "\`\`\`"
-            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-          exit "$EXIT_CODE"
+          if [ -n "$RESULT" ] || [ "$EXIT_CODE" -ne 0 ]; then
+            echo "$RESULT"
+            {
+              echo "### Vulnerabilities found"
+              echo ""
+              echo "| Severity | Package | CVEs | Fixed Version |"
+              echo "|---|---|---|---|"
+              while IFS='|' read -r pkg cves severity fixver; do
+                case "$severity" in
+                  Critical) emoji="🔴" ;;
+                  High)     emoji="🟠" ;;
+                  Medium)   emoji="🟡" ;;
+                  Low)      emoji="🔵" ;;
+                  *)        emoji="⚪" ;;
+                esac
+                echo "| ${emoji} ${severity} | \`${pkg}\` | ${cves} | \`${fixver}\` |"
+              done <<< "$RESULT"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          else
+            echo "No known vulnerabilities found." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

- Switches `arch-audit` to a pipe-delimited `--format` string (`%n|%c|%s|%v`) and renders the output as a markdown table in the step summary, with emoji severity indicators: 🔴 Critical, 🟠 High, 🟡 Medium, 🔵 Low, ⚪ Unknown — and the fixed version column showing what you'd need to upgrade to
- Supersedes #160 — folds in all reliability fixes: keyring refresh, drop `2>&1`, drop `--color auto`, fix summary always showing clean (arch-audit exits 0 even with vulnerabilities; now keys off non-empty output)

## Example summary output

| Severity | Package | CVEs | Fixed Version |
|---|---|---|---|
| 🔴 Critical | `linux` | CVE-2024-26925 | `6.8.5.arch1-1` |
| 🟠 High | `openssh` | CVE-2024-6387 | `9.8p1-1` |

Refs blouin-labs/issues#117

🤖 Generated with [Claude Code](https://claude.com/claude-code)