### PR TITLE
fix(ci): glob severity matching, no-fail, and pending reliability fixes

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -88,11 +88,11 @@ jobs:
               echo "|---|---|---|---|"
               while IFS='|' read -r pkg cves severity fixver; do
                 case "$severity" in
-                  *Critical*) emoji="🔴" ;;
-                  *High*)     emoji="🟠" ;;
-                  *Medium*)   emoji="🟡" ;;
-                  *Low*)      emoji="🔵" ;;
-                  *)          emoji="⚪" ;;
+                  Critical*) emoji="🔴" ;;
+                  High*)     emoji="🟠" ;;
+                  Medium*)   emoji="🟡" ;;
+                  Low*)      emoji="🔵" ;;
+                  *)         emoji="⚪" ;;
                 esac
                 echo "| ${emoji} ${severity} | \`${pkg}\` | ${cves} | \`${fixver}\` |"
               done <<< "$RESULT"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,7 +24,9 @@ jobs:
       image: archlinux/archlinux:latest
     steps:
       - name: Install arch-audit
-        run: pacman -Sy --noconfirm arch-audit jq unzip
+        run: |
+          pacman -Sy --noconfirm archlinux-keyring
+          pacman -Sy --noconfirm arch-audit jq unzip
 
       - name: Resolve main HEAD SHA
         id: sha
@@ -67,26 +69,34 @@ jobs:
       - name: Run arch-audit
         run: |
           set +e
-          RESULT=$(arch-audit --dbpath /tmp/audit-db --color auto --show-cve 2>&1)
-          EXIT_CODE=$?
+          RESULT=$(arch-audit --dbpath /tmp/audit-db --show-cve --format "%n|%c|%s|%v")
           set -e
-
-          echo "$RESULT"
 
           {
             echo "## arch-audit — harbor-srv ($(date -u '+%Y-%m-%d'))"
             echo ""
             echo "**Build:** \`${{ steps.sha.outputs.short }}\`"
             echo ""
-            if [ "$EXIT_CODE" -eq 0 ]; then
-              echo "No known vulnerabilities found."
-            else
-              echo "### Vulnerabilities found"
-              echo ""
-              echo "\`\`\`"
-              echo "$RESULT"
-              echo "\`\`\`"
-            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-          exit "$EXIT_CODE"
+          if [ -n "$RESULT" ]; then
+            echo "$RESULT"
+            {
+              echo "### Vulnerabilities found"
+              echo ""
+              echo "| Severity | Package | CVEs | Fixed Version |"
+              echo "|---|---|---|---|"
+              while IFS='|' read -r pkg cves severity fixver; do
+                case "$severity" in
+                  *Critical*) emoji="🔴" ;;
+                  *High*)     emoji="🟠" ;;
+                  *Medium*)   emoji="🟡" ;;
+                  *Low*)      emoji="🔵" ;;
+                  *)          emoji="⚪" ;;
+                esac
+                echo "| ${emoji} ${severity} | \`${pkg}\` | ${cves} | \`${fixver}\` |"
+              done <<< "$RESULT"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No known vulnerabilities found." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

- **Fix severity matching**: case statement now uses glob patterns (`*Critical*`, `*High*`, etc.) to match arch-audit output like "Medium risk" rather than exact strings
- **No-fail on vulnerabilities**: workflow is informational — there will always be open CVEs; removed `exit 1` so the job passes regardless
- **Supersedes #160 and #161**: folds in all pending fixes (keyring refresh, drop `2>&1`, drop `--color auto`, summary bug fix, structured markdown table with severity dots and fixed version column)

Refs blouin-labs/issues#117

🤖 Generated with [Claude Code](https://claude.com/claude-code)