### PR TITLE
feat(ci): automated Arch snapshot upgrade workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,9 @@ jobs:
     runs-on: ${{ fromJSON(needs.select-runner.outputs.runner) }}
     needs: select-runner
     container:
-      # archlinux/archlinux:latest — pinned digest matches ARCH_SNAPSHOT above
-      image: archlinux/archlinux@sha256:0e2b66488c60a96c65041cde5e754957a880b760dd4f00865ed09c131a51cd44
+      # Intentionally unpinned — build tools (pacstrap, e2fsprogs, zstd) are
+      # updated via pacman -Syu each run. Output reproducibility is provided by ARCH_SNAPSHOT alone.
+      image: archlinux/archlinux:latest
       options: --privileged
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,8 @@
 ---
 name: Build
 
-# Snapshot date and Docker image digest are pinned together.
-# To upgrade the full stack, update both values here and open a PR.
-# See README.md "Updating the stack" for the full process.
+# ARCH_SNAPSHOT pins all package versions. The build container is intentionally
+# unpinned — see README.md "Updating the stack" for the upgrade process.
 env:
   ARCH_SNAPSHOT: "2026/03/22"  # archive.archlinux.org date — update to upgrade
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -105,10 +105,11 @@ jobs:
           DATE_SLUG=$(echo "${NEW_SNAPSHOT}" | tr '/' '-')
           BRANCH="chore/upgrade-arch-${DATE_SLUG}"
 
-          # Idempotent: skip if a PR is already open for this branch
-          if gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number' \
+          # Idempotent: skip if a PR exists (open or closed) for this branch.
+          # A closed PR means the upgrade was deliberately rejected — don't reopen it.
+          if gh pr list --head "${BRANCH}" --state all --json number --jq '.[0].number' \
               | grep -q '[0-9]'; then
-            echo "PR already open for ${BRANCH} — skipping."
+            echo "PR already exists for ${BRANCH} — skipping."
             exit 0
           fi
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,163 @@
+---
+name: Upgrade
+
+# Opens a PR against staging when a newer Arch snapshot or container digest is available.
+# Both values in build.yml are updated atomically in a single commit.
+
+on:
+  schedule:
+    - cron: '0 10 * * 1'  # Weekly, Monday 10:00 UTC
+  workflow_dispatch:
+    inputs:
+      arch_snapshot:
+        description: 'Override ARCH_SNAPSHOT (YYYY/MM/DD) — leave blank to auto-detect'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: staging
+
+      - name: Detect latest archive date
+        id: archive
+        run: |
+          if [ -n "${{ inputs.arch_snapshot }}" ]; then
+            echo "snapshot=${{ inputs.arch_snapshot }}" >> "$GITHUB_OUTPUT"
+          else
+            TIMESTAMP=$(curl -sf https://archive.archlinux.org/repos/last/lastsync)
+            SNAPSHOT=$(date -u -d "@${TIMESTAMP}" '+%Y/%m/%d')
+            echo "snapshot=${SNAPSHOT}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect latest container digest
+        id: image
+        run: |
+          TOKEN=$(curl -sf \
+            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:archlinux/archlinux:pull" \
+            | jq -r '.token')
+          DIGEST=$(curl -sfI \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+            "https://registry-1.docker.io/v2/archlinux/archlinux/manifests/latest" \
+            | grep -i '^docker-content-digest:' \
+            | awk '{print $2}' \
+            | tr -d $'\r')
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Read current pinned values
+        id: current
+        run: |
+          SNAPSHOT=$(grep 'ARCH_SNAPSHOT:' .github/workflows/build.yml \
+            | grep -oP '(?<=")[^"]+(?=")')
+          DIGEST=$(grep 'archlinux/archlinux@' .github/workflows/build.yml \
+            | grep -oP 'sha256:[a-f0-9]+')
+          echo "snapshot=${SNAPSHOT}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if update is needed
+        id: check
+        env:
+          NEW_SNAPSHOT: ${{ steps.archive.outputs.snapshot }}
+          NEW_DIGEST: ${{ steps.image.outputs.digest }}
+          CUR_SNAPSHOT: ${{ steps.current.outputs.snapshot }}
+          CUR_DIGEST: ${{ steps.current.outputs.digest }}
+        run: |
+          echo "Current: snapshot=${CUR_SNAPSHOT}  digest=${CUR_DIGEST:0:19}..."
+          echo "Latest:  snapshot=${NEW_SNAPSHOT}  digest=${NEW_DIGEST:0:19}..."
+          if [ "${CUR_SNAPSHOT}" = "${NEW_SNAPSHOT}" ] && [ "${CUR_DIGEST}" = "${NEW_DIGEST}" ]; then
+            echo "Already up to date."
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Update needed."
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Patch build.yml
+        if: steps.check.outputs.needed == 'true'
+        env:
+          NEW_SNAPSHOT: ${{ steps.archive.outputs.snapshot }}
+          NEW_DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          sed -i \
+            's|ARCH_SNAPSHOT: ".*"|ARCH_SNAPSHOT: "'"${NEW_SNAPSHOT}"'"|' \
+            .github/workflows/build.yml
+          sed -i \
+            's|archlinux/archlinux@sha256:[a-f0-9]*|archlinux/archlinux@'"${NEW_DIGEST}"'|' \
+            .github/workflows/build.yml
+
+      - name: Open PR
+        if: steps.check.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_SNAPSHOT: ${{ steps.archive.outputs.snapshot }}
+          NEW_DIGEST: ${{ steps.image.outputs.digest }}
+          CUR_SNAPSHOT: ${{ steps.current.outputs.snapshot }}
+          CUR_DIGEST: ${{ steps.current.outputs.digest }}
+        run: |
+          DATE_SLUG=$(echo "${NEW_SNAPSHOT}" | tr '/' '-')
+          BRANCH="chore/upgrade-arch-${DATE_SLUG}"
+
+          # Idempotent: skip if a PR is already open for this branch
+          if gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number' \
+              | grep -q '[0-9]'; then
+            echo "PR already open for ${BRANCH} — skipping."
+            exit 0
+          fi
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git checkout -b "${BRANCH}"
+          git add .github/workflows/build.yml
+          git commit -m "chore: upgrade Arch snapshot to ${NEW_SNAPSHOT}"
+          git push origin "${BRANCH}"
+
+          cat > /tmp/pr-body.md <<EOF
+## Arch snapshot upgrade
+
+| | Before | After |
+|---|---|---|
+| \`ARCH_SNAPSHOT\` | \`${CUR_SNAPSHOT}\` | \`${NEW_SNAPSHOT}\` |
+| Container digest | \`${CUR_DIGEST:0:19}...\` | \`${NEW_DIGEST:0:19}...\` |
+
+Archive index: https://archive.archlinux.org/repos/${NEW_SNAPSHOT}/
+
+Refs blouin-labs/issues#119
+EOF
+
+          gh pr create \
+            --base staging \
+            --head "${BRANCH}" \
+            --title "chore: upgrade Arch snapshot to ${NEW_SNAPSHOT}" \
+            --body-file /tmp/pr-body.md
+
+      - name: Write summary
+        if: always()
+        env:
+          NEW_SNAPSHOT: ${{ steps.archive.outputs.snapshot }}
+          NEW_DIGEST: ${{ steps.image.outputs.digest }}
+          CUR_SNAPSHOT: ${{ steps.current.outputs.snapshot }}
+          CUR_DIGEST: ${{ steps.current.outputs.digest }}
+          NEEDED: ${{ steps.check.outputs.needed }}
+        run: |
+          {
+            echo "## Upgrade check — $(date -u '+%Y-%m-%d')"
+            echo ""
+            echo "| | Current | Latest |"
+            echo "|---|---|---|"
+            echo "| \`ARCH_SNAPSHOT\` | \`${CUR_SNAPSHOT}\` | \`${NEW_SNAPSHOT}\` |"
+            echo "| Container digest | \`${CUR_DIGEST:0:19}...\` | \`${NEW_DIGEST:0:19}...\` |"
+            echo ""
+            if [ "${NEEDED}" = "true" ]; then
+              echo "**PR opened.**"
+            else
+              echo "Already up to date — no PR needed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -119,18 +119,18 @@ jobs:
           git commit -m "chore: upgrade Arch snapshot to ${NEW_SNAPSHOT}"
           git push origin "${BRANCH}"
 
-          cat > /tmp/pr-body.md <<EOF
-## Arch snapshot upgrade
-
-| | Before | After |
-|---|---|---|
-| \`ARCH_SNAPSHOT\` | \`${CUR_SNAPSHOT}\` | \`${NEW_SNAPSHOT}\` |
-| Container digest | \`${CUR_DIGEST:0:19}...\` | \`${NEW_DIGEST:0:19}...\` |
-
-Archive index: https://archive.archlinux.org/repos/${NEW_SNAPSHOT}/
-
-Refs blouin-labs/issues#119
-EOF
+          {
+            echo "## Arch snapshot upgrade"
+            echo ""
+            echo "| | Before | After |"
+            echo "|---|---|---|"
+            echo "| \`ARCH_SNAPSHOT\` | \`${CUR_SNAPSHOT}\` | \`${NEW_SNAPSHOT}\` |"
+            echo "| Container digest | \`${CUR_DIGEST:0:19}...\` | \`${NEW_DIGEST:0:19}...\` |"
+            echo ""
+            echo "Archive index: https://archive.archlinux.org/repos/${NEW_SNAPSHOT}/"
+            echo ""
+            echo "Refs blouin-labs/issues#119"
+          } > /tmp/pr-body.md
 
           gh pr create \
             --base staging \

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,8 +1,8 @@
 ---
 name: Upgrade
 
-# Opens a PR against staging when a newer Arch snapshot or container digest is available.
-# Both values in build.yml are updated atomically in a single commit.
+# Opens a PR against staging when a newer Arch snapshot is available.
+# ARCH_SNAPSHOT in build.yml is the sole reproducibility pin — the build container is intentionally unpinned.
 
 on:
   schedule:
@@ -37,42 +37,22 @@ jobs:
             echo "snapshot=${SNAPSHOT}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Detect latest container digest
-        id: image
-        run: |
-          TOKEN=$(curl -sf \
-            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:archlinux/archlinux:pull" \
-            | jq -r '.token')
-          DIGEST=$(curl -sfI \
-            -H "Authorization: Bearer ${TOKEN}" \
-            -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
-            "https://registry-1.docker.io/v2/archlinux/archlinux/manifests/latest" \
-            | grep -i '^docker-content-digest:' \
-            | awk '{print $2}' \
-            | tr -d $'\r')
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-
-      - name: Read current pinned values
+      - name: Read current snapshot
         id: current
         run: |
           SNAPSHOT=$(grep 'ARCH_SNAPSHOT:' .github/workflows/build.yml \
             | grep -oP '(?<=")[^"]+(?=")')
-          DIGEST=$(grep 'archlinux/archlinux@' .github/workflows/build.yml \
-            | grep -oP 'sha256:[a-f0-9]+')
           echo "snapshot=${SNAPSHOT}" >> "$GITHUB_OUTPUT"
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Check if update is needed
         id: check
         env:
           NEW_SNAPSHOT: ${{ steps.archive.outputs.snapshot }}
-          NEW_DIGEST: ${{ steps.image.outputs.digest }}
           CUR_SNAPSHOT: ${{ steps.current.outputs.snapshot }}
-          CUR_DIGEST: ${{ steps.current.outputs.digest }}
         run: |
-          echo "Current: snapshot=${CUR_SNAPSHOT}  digest=${CUR_DIGEST:0:19}..."
-          echo "Latest:  snapshot=${NEW_SNAPSHOT}  digest=${NEW_DIGEST:0:19}..."
-          if [ "${CUR_SNAPSHOT}" = "${NEW_SNAPSHOT}" ] && [ "${CUR_DIGEST}" = "${NEW_DIGEST}" ]; then
+          echo "Current: ${CUR_SNAPSHOT}"
+          echo "Latest:  ${NEW_SNAPSHOT}"
+          if [ "${CUR_SNAPSHOT}" = "${NEW_SNAPSHOT}" ]; then
             echo "Already up to date."
             echo "needed=false" >> "$GITHUB_OUTPUT"
           else
@@ -84,13 +64,9 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         env:
           NEW_SNAPSHOT: ${{ steps.archive.outputs.snapshot }}
-          NEW_DIGEST: ${{ steps.image.outputs.digest }}
         run: |
           sed -i \
             's|ARCH_SNAPSHOT: ".*"|ARCH_SNAPSHOT: "'"${NEW_SNAPSHOT}"'"|' \
-            .github/workflows/build.yml
-          sed -i \
-            's|archlinux/archlinux@sha256:[a-f0-9]*|archlinux/archlinux@'"${NEW_DIGEST}"'|' \
             .github/workflows/build.yml
 
       - name: Open PR
@@ -98,9 +74,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_SNAPSHOT: ${{ steps.archive.outputs.snapshot }}
-          NEW_DIGEST: ${{ steps.image.outputs.digest }}
           CUR_SNAPSHOT: ${{ steps.current.outputs.snapshot }}
-          CUR_DIGEST: ${{ steps.current.outputs.digest }}
         run: |
           DATE_SLUG=$(echo "${NEW_SNAPSHOT}" | tr '/' '-')
           BRANCH="chore/upgrade-arch-${DATE_SLUG}"
@@ -126,7 +100,6 @@ jobs:
             echo "| | Before | After |"
             echo "|---|---|---|"
             echo "| \`ARCH_SNAPSHOT\` | \`${CUR_SNAPSHOT}\` | \`${NEW_SNAPSHOT}\` |"
-            echo "| Container digest | \`${CUR_DIGEST:0:19}...\` | \`${NEW_DIGEST:0:19}...\` |"
             echo ""
             echo "Archive index: https://archive.archlinux.org/repos/${NEW_SNAPSHOT}/"
             echo ""
@@ -143,9 +116,7 @@ jobs:
         if: always()
         env:
           NEW_SNAPSHOT: ${{ steps.archive.outputs.snapshot }}
-          NEW_DIGEST: ${{ steps.image.outputs.digest }}
           CUR_SNAPSHOT: ${{ steps.current.outputs.snapshot }}
-          CUR_DIGEST: ${{ steps.current.outputs.digest }}
           NEEDED: ${{ steps.check.outputs.needed }}
         run: |
           {
@@ -154,7 +125,6 @@ jobs:
             echo "| | Current | Latest |"
             echo "|---|---|---|"
             echo "| \`ARCH_SNAPSHOT\` | \`${CUR_SNAPSHOT}\` | \`${NEW_SNAPSHOT}\` |"
-            echo "| Container digest | \`${CUR_DIGEST:0:19}...\` | \`${NEW_DIGEST:0:19}...\` |"
             echo ""
             if [ "${NEEDED}" = "true" ]; then
               echo "**PR opened.**"

--- a/README.md
+++ b/README.md
@@ -158,14 +158,8 @@ flowchart TD
 
 ## Updating the stack
 
-The build pins all package versions and the build environment to a snapshot date. To upgrade to a newer point in time, edit **`.github/workflows/build.yml`** and **`.github/workflows/check.yml`**: two adjacent values in each:
+All package versions are pinned to `ARCH_SNAPSHOT` in `.github/workflows/build.yml`. The build container (`archlinux/archlinux:latest`) is intentionally unpinned — it only provides scaffolding tools (`pacstrap`, `e2fsprogs`, etc.) that don't affect the built image.
 
-1. Update `ARCH_SNAPSHOT` to the new date (`YYYY/MM/DD`). Check [archive.archlinux.org/repos](https://archive.archlinux.org/repos/) to confirm the date is available.
-2. Update the `container.image` digest to match. Fetch it with:
+Upgrades are automated: the **Upgrade** workflow runs every Monday and opens a PR when a newer snapshot is available at [archive.archlinux.org](https://archive.archlinux.org/repos/). To trigger one immediately, run it manually via `workflow_dispatch`.
 
-```bash
-docker manifest inspect --verbose archlinux/archlinux:latest \
-  | grep -m1 '"digest"' | awk -F'"' '{print $4}'
-```
-
-3. Open a PR—CI builds the new image for review before it reaches the server.
+To pin to a specific date manually, edit `ARCH_SNAPSHOT` in `.github/workflows/build.yml` and open a PR — CI builds the new image for review before it reaches the server.

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ flowchart TD
 
 ## Updating the stack
 
-All package versions are pinned to `ARCH_SNAPSHOT` in `.github/workflows/build.yml`. The build container (`archlinux/archlinux:latest`) is intentionally unpinned — it only provides scaffolding tools (`pacstrap`, `e2fsprogs`, etc.) that don't affect the built image.
+The build pins all package versions to `ARCH_SNAPSHOT` in `.github/workflows/build.yml`. The build container (`archlinux/archlinux:latest`) runs unpinned: it only provides scaffolding tools (`pacstrap`, `e2fsprogs`, etc.) with no effect on the built image.
 
-Upgrades are automated: the **Upgrade** workflow runs every Monday and opens a PR when a newer snapshot is available at [archive.archlinux.org](https://archive.archlinux.org/repos/). To trigger one immediately, run it manually via `workflow_dispatch`.
+The **Upgrade** workflow runs every Monday and opens a PR when a newer snapshot appears at [archive.archlinux.org](https://archive.archlinux.org/repos/). Use `workflow_dispatch` to trigger an upgrade on demand.
 
-To pin to a specific date manually, edit `ARCH_SNAPSHOT` in `.github/workflows/build.yml` and open a PR — CI builds the new image for review before it reaches the server.
+To pin to a specific date manually, edit `ARCH_SNAPSHOT` in `.github/workflows/build.yml` and open a PR. CI builds the new image for review before it reaches the server.


### PR DESCRIPTION
## Summary

- Adds `upgrade.yml` — a scheduled workflow (Monday 10:00 UTC) that opens a PR when the Arch snapshot or container digest is stale
- Detects latest date from `archive.archlinux.org/repos/last/lastsync` (no date-probing)
- Fetches `archlinux/archlinux:latest` manifest digest via Docker registry API (no pull needed)
- Updates both coupled values in `build.yml` atomically in a single commit
- Idempotent: skips PR creation if one is already open for the same branch
- Also supports `workflow_dispatch` with an optional `ARCH_SNAPSHOT` date override

## Test plan

- [ ] Trigger via `workflow_dispatch` (no date override) — confirm PR is opened with correct snapshot and digest values
- [ ] Trigger again — confirm idempotency (no duplicate PR)
- [ ] Trigger via `workflow_dispatch` with explicit date override — confirm that date is used
- [ ] Confirm `check.yml` (actionlint) passes on this PR

Refs blouin-labs/issues#119