### PR TITLE
fix(ci): force-push upgrade branch to recover from orphaned remote branch

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -86,7 +86,7 @@ jobs:
           git checkout -b "${BRANCH}"
           git add arch-snapshot
           git commit -m "chore: upgrade Arch snapshot to ${NEW_SNAPSHOT}"
-          git push origin "${BRANCH}"
+          git push --force origin "${BRANCH}"
 
           {
             echo "## Arch snapshot upgrade"


### PR DESCRIPTION
A previous failed run (workflows permission, then PR creation permission) pushed `chore/upgrade-arch-*` to the remote but never created a PR. On retry, the idempotency check finds no PR and proceeds, but the push is rejected because the branch already exists with a different commit.

Force-push is safe here: this is a bot-managed branch, always freshly created from staging with a single deterministic commit.

Refs blouin-labs/issues#119