### PR TITLE
fix: enable NFSv4 ID mapping for Kerberos NFS mount

### DIFF
--- a/profile/airootfs/etc/idmapd.conf
+++ b/profile/airootfs/etc/idmapd.conf
@@ -1,0 +1,6 @@
+[General]
+Domain = harbor.local
+
+[Mapping]
+Nobody-User = nobody
+Nobody-Group = nobody

--- a/profile/airootfs/etc/modprobe.d/nfs-idmap.conf
+++ b/profile/airootfs/etc/modprobe.d/nfs-idmap.conf
@@ -1,0 +1,1 @@
+options nfs nfs4_disable_idmapping=N


### PR DESCRIPTION
## Summary
- Adds `/etc/idmapd.conf` with `Domain = harbor.local` to match the Synology NFSv4 domain
- Adds `/etc/modprobe.d/nfs-idmap.conf` to enable NFSv4 ID mapping (`nfs4_disable_idmapping=N`)
- Without these, all files on the NFS mount are owned by `nobody` because the client can't translate NFSv4 `user@DOMAIN` strings to local UIDs when using `sec=krb5i`

## Context
The Synology NFS squash setting ("No mapping") has no effect with Kerberos NFS — identity is determined entirely by NFSv4 idmap. Three things were broken: idmapping disabled on the client, domain mismatch (`localdomain` vs `harbor.local`), and the Synology principal mapping pointed to the wrong user. The Synology-side fix (principal mapping `jblouin` → `root`) was applied via DSM. This PR persists the client-side fixes.

Refs blouin-labs/issues#116

## Test plan
- [ ] After deploy, `touch` a file on `/mnt/synology/harbor_srv/` — should be `root:root`, not `nobody:nobody`
- [ ] Restart Lubelog container — confirm login works and no DataProtection errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)